### PR TITLE
Add get_watch_only_username

### DIFF
--- a/include/gdk.h
+++ b/include/gdk.h
@@ -133,6 +133,14 @@ GDK_API int GA_login_with_pin(struct GA_session* session, const char* pin, const
 GDK_API int GA_set_watch_only(struct GA_session* session, const char* username, const char* password);
 
 /**
+ * Get the current watch-only login for the wallet, if any.
+ *
+ * :param session: The session to use.
+ * :param username: Destination for the watch-only username. Empty string if not set.
+ */
+GDK_API int GA_get_watch_only_username(struct GA_session* session, char** username);
+
+/**
  * Authenticate a user in watch only mode.
  *
  * :param session: The session to use.

--- a/src/ffi_c.cpp
+++ b/src/ffi_c.cpp
@@ -191,6 +191,9 @@ GDK_DEFINE_C_FUNCTION_3(GA_login_watch_only, struct GA_session*, session, const 
 GDK_DEFINE_C_FUNCTION_3(GA_set_watch_only, struct GA_session*, session, const char*, username, const char*, password,
     { session->set_watch_only(username, password); })
 
+GDK_DEFINE_C_FUNCTION_2(GA_get_watch_only_username, struct GA_session*, session, char**, username,
+    { *username = to_c_string(session->get_watch_only_username()); })
+
 GDK_DEFINE_C_FUNCTION_2(GA_get_fee_estimates, struct GA_session*, session, GA_json**, estimates,
     { *json_cast(estimates) = new nlohmann::json(session->get_fee_estimates()); })
 

--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -1234,6 +1234,14 @@ namespace sdk {
         return r;
     }
 
+    std::string ga_session::get_watch_only_username()
+    {
+        nlohmann::json r;
+        wamp_call([&r](wamp_call_result result) { r = get_json_result(result.get()); },
+            "com.greenaddress.addressbook.get_sync_status");
+        return json_get_value(r, "username");
+    }
+
     // Idempotent
     bool ga_session::remove_account(const nlohmann::json& twofactor_data)
     {

--- a/src/ga_session.hpp
+++ b/src/ga_session.hpp
@@ -71,6 +71,7 @@ namespace sdk {
         void on_failed_login();
 
         bool set_watch_only(const std::string& username, const std::string& password);
+        std::string get_watch_only_username();
         bool remove_account(const nlohmann::json& twofactor_data);
 
         template <typename T>

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -160,6 +160,12 @@ namespace sdk {
         return exception_wrapper([&] { return m_impl->set_watch_only(username, password); });
     }
 
+    std::string session::get_watch_only_username()
+    {
+        GDK_RUNTIME_ASSERT(m_impl != nullptr);
+        return exception_wrapper([&] { return m_impl->get_watch_only_username(); });
+    }
+
     bool session::remove_account(const nlohmann::json& twofactor_data)
     {
         GDK_RUNTIME_ASSERT(m_impl != nullptr);

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -45,6 +45,7 @@ namespace sdk {
         void login_with_pin(const std::string& pin, const nlohmann::json& pin_data);
         void login_watch_only(const std::string& username, const std::string& password);
         bool set_watch_only(const std::string& username, const std::string& password);
+        std::string get_watch_only_username();
         bool remove_account(const nlohmann::json& twofactor_data);
 
         uint32_t get_next_subaccount();

--- a/src/swift/GreenAddress/Sources/GreenAddress/GreenAddress.swift
+++ b/src/swift/GreenAddress/Sources/GreenAddress/GreenAddress.swift
@@ -245,6 +245,15 @@ public class Session {
         try callWrapper(fun: GA_set_watch_only(session, username, password))
     }
 
+    public func getWatchOnlyUsername() throws -> String {
+        var buff: UnsafeMutablePointer<Int8>? = nil
+        try callWrapper(fun: GA_get_watch_only_username(session, &buff))
+        defer {
+            GA_destroy_string(buff)
+        }
+        return String(cString: buff!)
+    }
+
     public func removeAccount() throws -> TwoFactorCall {
         var optr: OpaquePointer? = nil;
         try callWrapper(fun: GA_remove_account(session, &optr));

--- a/src/swig_java/swig_gasdk.i
+++ b/src/swig_java/swig_gasdk.i
@@ -520,6 +520,7 @@ LOCALFUNC jbyteArray create_array(JNIEnv *jenv, const unsigned char* p, size_t l
 %returns_struct(GA_set_pin, GA_json)
 %returns_void__(GA_set_transaction_memo)
 %returns_void__(GA_set_watch_only)
+%returns_string(GA_get_watch_only_username)
 %returns_struct(GA_sign_transaction, GA_auth_handler)
 %returns_void__(GA_auth_handler_call)
 %returns_struct(GA_twofactor_cancel_reset, GA_auth_handler)

--- a/src/swig_python/python_extra.py_in
+++ b/src/swig_python/python_extra.py_in
@@ -117,6 +117,9 @@ class Session(object):
         set_watch_only(self.session_obj, username, password)
         return self
 
+    def get_watch_only_username(self):
+        return get_watch_only_username(self.session_obj)
+
     def login_watch_only(self, username, password):
         login_watch_only(self.session_obj, username, password)
         return self


### PR DESCRIPTION
Clients require access to the current watch only login username to
display in settings.