### PR TITLE
Correctly account for spending limits for RBF

### DIFF
--- a/src/ga_auth_handlers.hpp
+++ b/src/ga_auth_handlers.hpp
@@ -126,7 +126,7 @@ namespace sdk {
         nlohmann::json m_limit_details;
         bool m_twofactor_required;
         bool m_under_limit;
-        bool m_bumping_fee;
+        uint64_t m_bump_amount = 0;
     };
 
     class twofactor_reset_call : public auth_handler {


### PR DESCRIPTION
When sending a transaction which is replacing a previous transaction via
RBF only the fee delta should be deducted from the spending limits
otherwise the amount is effectively double counted and 2FA will be
requested where it is not required.