### PR TITLE
Fix handling of #password error from server

### DIFF
--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -2164,20 +2164,8 @@ namespace sdk {
     std::vector<unsigned char> ga_session::get_pin_password(const std::string& pin, const std::string& pin_identifier)
     {
         std::string password;
-        std::string error;
-        wamp_call(
-            [&password, &error](wamp_call_result result) {
-                try {
-                    password = result.get().argument<std::string>(0);
-                } catch (const std::exception& e) {
-                    error = e.what();
-                }
-            },
+        wamp_call([&password](wamp_call_result result) { password = result.get().argument<std::string>(0); },
             "com.greenaddress.pin.get_password", pin, pin_identifier);
-
-        if (!error.empty()) {
-            throw login_error(error);
-        }
 
         return std::vector<unsigned char>(password.begin(), password.end());
     }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -48,11 +48,16 @@ namespace sdk {
             disconnect();
             throw reconnect_error();
         } catch (const autobahn::call_error& e) {
+            std::pair<std::string, std::string> details;
             try {
-                std::pair<std::string, std::string> details = get_error_details(e);
+                details = get_error_details(e);
                 GDK_LOG_SEV(log_level::debug) << "server exception (" << details.first << "):" << details.second;
             } catch (const std::exception&) {
                 log_exception("call error:", e);
+            }
+            if (details.first == "password") {
+                // Server sends this response if the PIN is incorrect
+                throw login_error(details.second);
             }
             throw;
         } catch (const assertion_error& e) {

--- a/src/swig_python/swig_gasdk.i
+++ b/src/swig_python/swig_gasdk.i
@@ -12,6 +12,9 @@ static int check_result(int result)
     case GA_ERROR:
         PyErr_SetString(PyExc_RuntimeError, "Failed");
         break;
+    case GA_NOT_AUTHORIZED:
+        PyErr_SetString(PyExc_RuntimeError, "Not Authorized");
+        break;
     default: /* FIXME */
         PyErr_SetString(PyExc_RuntimeError, "Connection Error");
         break;


### PR DESCRIPTION
Throw login_error only in the case where the server responds with 'No
password for device' to distinguish from other errors.