### PR TITLE
Clarify documentation of subaccount parameter

### DIFF
--- a/include/gdk.h
+++ b/include/gdk.h
@@ -208,7 +208,7 @@ GDK_API int GA_get_subaccounts(struct GA_session* session, GA_json** subaccounts
  * Get subaccount details.
  *
  * :param session: The session to use.
- * :param subaccount: Subaccount to get.
+ * :param subaccount: The value of "pointer" from :ref:`subaccount-list` for the subaccount.
  * :param output: Destination for the :ref:`subaccount-detail`.
  *|     Returned GA_json should be freed using `GA_destroy_json`.
  */
@@ -230,7 +230,8 @@ GDK_API int GA_get_transactions(struct GA_session* session, const GA_json* detai
  * Get a new address to receive coins to.
  *
  * :param session: The session to use.
- * :param subaccount: The subaccount to generate an address for.
+ * :param subaccount: The value of "pointer" from :ref:`subaccount-list` or
+ *|                   :ref:`subaccount-detail` for the subaccount to generate an address for.
  * :param output: The generated address.
  *|     Returned string should be freed using `GA_destroy_string`.
  */


### PR DESCRIPTION
The integer subaccount parameter used to identify subaccounts is
actually the subaccount pointer value, which is usually but not
necessarily the same as the index of the subaccount from
get_subaccounts. Make this explicit in the docs.