### PR TITLE
csvtime fixes in get_settings and get_receive_address

### DIFF
--- a/docs/source/gdk-json.rst
+++ b/docs/source/gdk-json.rst
@@ -605,6 +605,8 @@ Settings JSON
 
   {
     "altimeout": 10,
+    "csvtime": 51840,
+    "nlocktime": 12960,
     "notifications": {
       "email_incoming": true,
       "email_outgoing": true

--- a/include/gdk.h
+++ b/include/gdk.h
@@ -225,9 +225,11 @@ GDK_API int GA_remove_account(struct GA_session* session, struct GA_auth_handler
  *
  * :param session: The session to use.
  * :param details: The :ref:`subaccount`. "name" (which must not be already used in
- *|     the wallet) and "type" (either "2of2" or "2of3") must be populated. For
- *|     type "2of3" the caller may provide either "recovery_mnemonic" or "recovery_xpub"
- *|     if they do not wish to have a mnemonic passphrase generated automatically.
+ *|     the wallet) and "type" (either "2of2", "2of2_no_recovery" or "2of3") must be
+ *|     populated. Type "2of2_no_recovery" is available only for Liquid networks and
+ *|     always requires both keys for spending. For type "2of3" the caller may provide
+ *|     either "recovery_mnemonic" or "recovery_xpub" if they do not wish to have a
+ *|     mnemonic passphrase generated automatically.
  *|     All other fields are ignored.
  * :param subaccount: Destination for the created subaccount details. For 2of3
  *|     subaccounts the field "recovery_xpub" will be populated, and "recovery_mnemonic"

--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -2807,6 +2807,16 @@ namespace sdk {
             GDK_RUNTIME_ASSERT(server_address == user_address);
         }
 
+        if (addr_type == address_type::csv) {
+            uint32_t csv_blocks = get_csv_blocks_from_csv_redeem_script(server_script);
+            // This not only ensures that the csvtime is the one that was set
+            // by the user, but, more importantly, ensures that the csvtime is
+            // among the csv buckets. If it wasn't, coins held by such scripts
+            // may not be recoverable.
+            locker_t locker(m_mutex);
+            GDK_RUNTIME_ASSERT(csv_blocks == m_csv_blocks);
+        }
+
         // Only scriptpubkey, we will add the blinding key later
         address["address"] = server_address;
 

--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -1116,7 +1116,17 @@ namespace sdk {
         cleanup_appearance_settings(locker, appearance);
 
         m_earliest_block_time = m_login_data["earliest_key_creation_time"];
+
+        // Check that csv blocks used are recoverable and provided by the server
+        const auto net_csv_buckets = m_net_params.csv_buckets();
+        for (uint32_t bucket : m_login_data["csv_times"]) {
+            if (std::find(net_csv_buckets.begin(), net_csv_buckets.end(), bucket) != net_csv_buckets.end()) {
+                m_csv_buckets.insert(m_csv_buckets.end(), bucket);
+            }
+        }
+        GDK_RUNTIME_ASSERT(m_csv_buckets.size() > 0);
         m_csv_blocks = m_login_data["csv_blocks"];
+        GDK_RUNTIME_ASSERT(std::find(m_csv_buckets.begin(), m_csv_buckets.end(), m_csv_blocks) != m_csv_buckets.end());
         if (!m_watch_only) {
             m_nlocktime = m_login_data["nlocktime_blocks"];
         }

--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -3387,11 +3387,14 @@ namespace sdk {
     {
         bool r = false;
         const uint32_t value = locktime_details.at("value");
+        locker_t locker(m_mutex);
+        // This not only saves a server round trip in case of bad value, but
+        // also ensures that the value is recoverable.
+        GDK_RUNTIME_ASSERT(std::find(m_csv_buckets.begin(), m_csv_buckets.end(), value) != m_csv_buckets.end());
         wamp_call([&r](wamp_call_result result) { r = result.get().argument<bool>(0); },
             "com.greenaddress.login.set_csvtime", value, as_messagepack(twofactor_data).get());
         GDK_RUNTIME_ASSERT(r);
 
-        locker_t locker(m_mutex);
         m_csv_blocks = value;
     }
 

--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -1116,6 +1116,7 @@ namespace sdk {
         cleanup_appearance_settings(locker, appearance);
 
         m_earliest_block_time = m_login_data["earliest_key_creation_time"];
+        m_csv_blocks = m_login_data["csv_blocks"];
         if (!m_watch_only) {
             m_nlocktime = m_login_data["nlocktime_blocks"];
         }
@@ -1539,6 +1540,7 @@ namespace sdk {
 
         settings["pricing"]["currency"] = m_fiat_currency;
         settings["pricing"]["exchange"] = m_fiat_source;
+        settings["csvtime"] = m_csv_blocks;
         if (!m_watch_only) {
             settings["nlocktime"] = m_nlocktime;
         }
@@ -3368,6 +3370,9 @@ namespace sdk {
         wamp_call([&r](wamp_call_result result) { r = result.get().argument<bool>(0); },
             "com.greenaddress.login.set_csvtime", value, as_messagepack(twofactor_data).get());
         GDK_RUNTIME_ASSERT(r);
+
+        locker_t locker(m_mutex);
+        m_csv_blocks = value;
     }
 
     void ga_session::set_nlocktime(const nlohmann::json& locktime_details, const nlohmann::json& twofactor_data)

--- a/src/ga_session.hpp
+++ b/src/ga_session.hpp
@@ -500,6 +500,7 @@ namespace sdk {
         std::string m_fiat_currency GDK_GUARDED_BY(m_mutex);
         uint64_t m_earliest_block_time GDK_GUARDED_BY(m_mutex);
         uint64_t m_nlocktime GDK_GUARDED_BY(m_mutex);
+        uint32_t m_csv_blocks GDK_GUARDED_BY(m_mutex);
 
         nlohmann::json m_assets;
 

--- a/src/ga_session.hpp
+++ b/src/ga_session.hpp
@@ -501,6 +501,7 @@ namespace sdk {
         uint64_t m_earliest_block_time GDK_GUARDED_BY(m_mutex);
         uint64_t m_nlocktime GDK_GUARDED_BY(m_mutex);
         uint32_t m_csv_blocks GDK_GUARDED_BY(m_mutex);
+        std::vector<uint32_t> m_csv_buckets GDK_GUARDED_BY(m_mutex);
 
         nlohmann::json m_assets;
 


### PR DESCRIPTION
Add `csvtime` to the json returned by `get_settings`.

Check address used correct `csvtime`.

Update `create_subaccount` docs.