### PR TITLE
tests: Use --jsonrpc-import to speed up electrs startup times

### DIFF
--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -157,6 +157,7 @@ pub fn setup(
         par_network,
         "--cookie",
         &cookie_value,
+        "--jsonrpc-import",
     ];
     if is_debug {
         args.push("-v");


### PR DESCRIPTION
Reading from the blkfiles is significantly slower when there aren't many blocks.