### PR TITLE
Do not report 2fa phone number for sms

### DIFF
--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -2969,8 +2969,10 @@ namespace sdk {
 
             nlohmann::json email_config
                 = { { "enabled", f["email"] }, { "confirmed", f["email_confirmed"] }, { "data", f["email_addr"] } };
+            // FIXME: the 'sms_number' field requires an updated server so treat it as optional until all backends
+            //        have been updated
             nlohmann::json sms_config
-                = { { "enabled", f["sms"] }, { "confirmed", f["sms"] }, { "data", f["phone_number"] } };
+                = { { "enabled", f["sms"] }, { "confirmed", f["sms"] }, { "data", json_get_value(f, "sms_number") } };
             nlohmann::json phone_config
                 = { { "enabled", f["phone"] }, { "confirmed", f["phone"] }, { "data", f["phone_number"] } };
             // Return the server generated gauth URL until gauth is enabled


### PR DESCRIPTION
Currently the server is only returning the 2fa phone number in the
config, not the sms number, and the gdk is returning that phone number
in the 2fa config data for sms, which is incorrect. Once the server is
fixed it will return the sms data separately.