### PR TITLE
Append gdk version to client user agent string

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -88,7 +88,7 @@ if infer.found()
 endif
 
 commit_id = vcs_tag('commit_id', input : 'version.h.in', output : 'version.h',
-                    command : ['git', '-C', meson.source_root(), 'rev-parse', 'HEAD'])
+                    command : ['git', '-C', meson.source_root(), 'rev-parse', '--short', 'HEAD'])
 sources += commit_id
 
 dependencies = subproject_deps + library_deps


### PR DESCRIPTION
    Reformat user agent string
    
    1) Enforce a maximum length of 64 characters (server will reject
       anything more)
    2) Use the short git commit id of the gdk version for brevity
    3) Append the client provided string to the gdk git commit id rather
       than replacing it