### PR TITLE
Add gdk-python/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/build
 /tor
 *~
 target/
+gdk-python/


### PR DESCRIPTION
Conventional destination for python wrapper build artifacts