### PR TITLE
[WIP] Support for subaccounts with multiple script types

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,6 +194,7 @@ test_rust:
     - DEBUG=1 ./launch_integration_tests.sh bitcoin
     - DEBUG=1 ./launch_integration_tests.sh liquid
     - DEBUG=1 ./launch_integration_tests.sh subaccounts
+    - DEBUG=1 ./launch_integration_tests.sh labels
     - DEBUG=1 ./launch_integration_tests.sh spv_cross_validate
     - DEBUG=1 ./launch_integration_tests.sh spv_cross_validation_session
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -193,6 +193,7 @@ test_rust:
     - cd subprojects/gdk_rust
     - DEBUG=1 ./launch_integration_tests.sh bitcoin
     - DEBUG=1 ./launch_integration_tests.sh liquid
+    - DEBUG=1 ./launch_integration_tests.sh subaccounts
     - DEBUG=1 ./launch_integration_tests.sh spv_cross_validate
     - DEBUG=1 ./launch_integration_tests.sh spv_cross_validation_session
 

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -131,6 +131,19 @@ pub struct GetTransactionsOpt {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct GetUnspentOpt {
+    pub subaccount: u32,
+    pub num_confs: Option<usize>, // unused
+    pub all_coins: Option<usize>, // unused
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct GetAddressOpt {
+    pub subaccount: u32,
+    pub address_type: Option<String>, // unused
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct SPVVerifyTx {
     pub txid: String,
     pub height: u32,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -144,6 +144,11 @@ pub struct GetAddressOpt {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct CreateAccountOpt {
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct SPVVerifyTx {
     pub txid: String,
     pub height: u32,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -126,7 +126,7 @@ pub struct CreateTransaction {
 pub struct GetTransactionsOpt {
     pub first: usize,
     pub count: usize,
-    pub subaccount: usize,
+    pub subaccount: u32,
     pub num_confs: Option<usize>,
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::error::Error;
+use crate::scripts::ScriptType;
 use bitcoin::hashes::core::fmt::Formatter;
 use bitcoin::util::bip32::{ChildNumber, DerivationPath};
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -143,9 +144,11 @@ pub struct GetAddressOpt {
     pub address_type: Option<String>, // unused
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CreateAccountOpt {
     pub name: String,
+    #[serde(rename = "type")]
+    pub script_type: ScriptType,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -303,7 +306,7 @@ pub struct AccountInfo {
     #[serde(rename = "pointer")]
     pub account_num: u32,
     #[serde(rename = "type")]
-    pub type_: String,
+    pub script_type: ScriptType,
     pub name: String,
     pub has_transactions: bool,
     pub satoshi: Balances,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -293,7 +293,11 @@ pub struct TxListItem {
     pub transaction_weight: usize,
 }
 
-pub struct Subaccount {
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AccountInfo {
+    #[serde(rename = "pointer")]
+    pub account_num: u32,
+    #[serde(rename = "type")]
     pub type_: String,
     pub name: String,
     pub has_transactions: bool,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -153,6 +153,12 @@ pub struct CreateAccountOpt {
     pub script_type: ScriptType,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct RenameAccountOpt {
+    pub subaccount: u32,
+    pub new_name: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct SPVVerifyTx {
     pub txid: String,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -315,7 +315,8 @@ pub struct AccountInfo {
     pub account_num: u32,
     #[serde(rename = "type")]
     pub script_type: ScriptType,
-    pub name: String,
+    #[serde(flatten)]
+    pub settings: AccountSettings,
     pub has_transactions: bool,
     pub satoshi: Balances,
 }
@@ -354,6 +355,19 @@ pub struct Settings {
     pub altimeout: u32,
     pub pricing: Pricing,
     pub sound: bool,
+}
+
+#[derive(Default, Serialize, Deserialize, Clone, Debug)]
+pub struct AccountSettings {
+    pub name: String,
+    pub hidden: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct UpdateAccountOpt {
+    pub subaccount: u32,
+    pub name: Option<String>,
+    pub hidden: Option<bool>,
 }
 
 /// {"icons":true,"assets":false,"refresh":false}

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -121,6 +121,8 @@ pub struct CreateTransaction {
     pub previous_transaction: HashMap<String, Value>,
     pub memo: Option<String>,
     pub utxos: Option<GetUnspentOutputs>,
+    /// Minimum number of confirmations for coin selection
+    pub num_confs: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -128,13 +130,13 @@ pub struct GetTransactionsOpt {
     pub first: usize,
     pub count: usize,
     pub subaccount: u32,
-    pub num_confs: Option<usize>,
+    pub num_confs: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GetUnspentOpt {
     pub subaccount: u32,
-    pub num_confs: Option<usize>, // unused
+    pub num_confs: Option<u32>,
     pub all_coins: Option<usize>, // unused
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -115,7 +115,7 @@ pub enum Notification {
 pub struct CreateTransaction {
     pub addressees: Vec<AddressAmount>,
     pub fee_rate: Option<u64>, // in satoshi/kbyte
-    pub subaccount: Option<u32>,
+    pub subaccount: u32,
     pub send_all: Option<bool>,
     #[serde(default)]
     pub previous_transaction: HashMap<String, Value>,

--- a/subprojects/gdk_rust/gdk_common/src/scripts.rs
+++ b/subprojects/gdk_rust/gdk_common/src/scripts.rs
@@ -1,7 +1,19 @@
+use serde::{Deserialize, Serialize};
+
 use bitcoin::blockdata::script::Builder;
 use bitcoin::hash_types::PubkeyHash;
 use bitcoin::hashes::Hash;
 use bitcoin::{Address, Network, PublicKey, Script};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ScriptType {
+    #[serde(rename(serialize = "p2sh-p2wpkh"))]
+    P2shP2wpkh,
+    #[serde(rename(serialize = "p2wpkh"))]
+    P2wpkh,
+    #[serde(rename(serialize = "p2pkh"))]
+    P2pkh,
+}
 
 // The following scripts are always using regtest network,
 // it is always ok because I am not interested in the address just in the script
@@ -20,4 +32,44 @@ pub fn p2shwpkh_script_sig(public_key: &PublicKey) -> Script {
         .push_slice(&PubkeyHash::hash(&public_key.to_bytes())[..])
         .into_script();
     Builder::new().push_slice(internal.as_bytes()).into_script()
+}
+
+impl ScriptType {
+    pub fn is_segwit(self) -> bool {
+        matches!(self, ScriptType::P2wpkh | ScriptType::P2shP2wpkh)
+    }
+
+    /// Returns a mock witness with the expected size
+    pub fn mock_witness(self) -> Vec<Vec<u8>> {
+        match self {
+            // signature (72) + compressed public key (33)
+            ScriptType::P2wpkh | ScriptType::P2shP2wpkh => vec![vec![0u8; 72], vec![0u8; 33]],
+            // empty for non-witness inputs
+            ScriptType::P2pkh => vec![],
+        }
+    }
+
+    /// Returns a mock script sig with the expected size
+    pub fn mock_script_sig(self) -> Vec<u8> {
+        match self {
+            // empty for native segwit
+            ScriptType::P2wpkh => vec![],
+            // OP_PUSHBYTES <22 bytes>
+            ScriptType::P2shP2wpkh => vec![0u8; 23],
+            // OP_PUSHBYTES <72 bytes sig> OP_PUSHBYTES <33 bytes compressed key>
+            ScriptType::P2pkh => vec![0u8; 107],
+        }
+    }
+
+    /// Returns a mock scriptPubkey with the expected size
+    pub fn mock_script_pubkey(self) -> Vec<u8> {
+        match self {
+            // OP_0 PUSHBYTES <20 bytes hash>
+            ScriptType::P2wpkh => vec![0u8; 22],
+            // OP_HASH160 PUSHBYTES <20 bytes hash> OP_EQUAL
+            ScriptType::P2shP2wpkh => vec![0u8; 23],
+            // OP_DUP OP_HASH160 OP_PUSHBYTES_20 <20 bytes hash> OP_EQUALVERIFY OP_CHECKSIG
+            ScriptType::P2pkh => vec![0u8; 25],
+        }
+    }
 }

--- a/subprojects/gdk_rust/gdk_common/src/scripts.rs
+++ b/subprojects/gdk_rust/gdk_common/src/scripts.rs
@@ -74,11 +74,11 @@ impl ScriptType {
     /// Returns a mock scriptPubkey with the expected size
     pub fn mock_script_pubkey(self) -> Vec<u8> {
         match self {
-            // OP_0 PUSHBYTES <20 bytes hash>
+            // OP_0 OP_PUSHBYTES <20 bytes hash>
             ScriptType::P2wpkh => vec![0u8; 22],
-            // OP_HASH160 PUSHBYTES <20 bytes hash> OP_EQUAL
+            // OP_HASH160 OP_PUSHBYTES <20 bytes hash> OP_EQUAL
             ScriptType::P2shP2wpkh => vec![0u8; 23],
-            // OP_DUP OP_HASH160 OP_PUSHBYTES_20 <20 bytes hash> OP_EQUALVERIFY OP_CHECKSIG
+            // OP_DUP OP_HASH160 OP_PUSHBYTES <20 bytes hash> OP_EQUALVERIFY OP_CHECKSIG
             ScriptType::P2pkh => vec![0u8; 25],
         }
     }

--- a/subprojects/gdk_rust/gdk_common/src/scripts.rs
+++ b/subprojects/gdk_rust/gdk_common/src/scripts.rs
@@ -8,12 +8,14 @@ use bitcoin::{Address, Network, PublicKey, Script};
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ScriptType {
     #[serde(rename(serialize = "p2sh-p2wpkh"))]
-    P2shP2wpkh,
+    P2shP2wpkh = 0,
     #[serde(rename(serialize = "p2wpkh"))]
-    P2wpkh,
+    P2wpkh = 1,
     #[serde(rename(serialize = "p2pkh"))]
-    P2pkh,
+    P2pkh = 2,
 }
+
+const TYPES: [ScriptType; 3] = [ScriptType::P2shP2wpkh, ScriptType::P2wpkh, ScriptType::P2pkh];
 
 // The following scripts are always using regtest network,
 // it is always ok because I am not interested in the address just in the script
@@ -35,6 +37,14 @@ pub fn p2shwpkh_script_sig(public_key: &PublicKey) -> Script {
 }
 
 impl ScriptType {
+    pub fn types() -> &'static [ScriptType] {
+        &TYPES
+    }
+
+    pub fn first_account_num(self) -> u32 {
+        self as u32
+    }
+
     pub fn is_segwit(self) -> bool {
         matches!(self, ScriptType::P2wpkh | ScriptType::P2shP2wpkh)
     }

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -30,7 +30,7 @@ pub trait Session<E> {
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
     fn get_balance(&self, subaccount: u32, num_confs: u32) -> Result<Balances, E>;
-    fn set_transaction_memo(&self, account_num: u32, txid: &str, memo: &str) -> Result<(), E>;
+    fn set_transaction_memo(&self, txid: &str, memo: &str) -> Result<(), E>;
     fn create_transaction(&mut self, details: &mut CreateTransaction)
         -> Result<TransactionMeta, E>;
     fn sign_transaction(&self, tx_detail_unsigned: &TransactionMeta) -> Result<TransactionMeta, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -28,13 +28,13 @@ pub trait Session<E> {
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
     fn get_balance(&self, num_confs: u32, subaccount: Option<u32>) -> Result<Balances, E>;
-    fn set_transaction_memo(&self, txid: &str, memo: &str) -> Result<(), E>;
+    fn set_transaction_memo(&self, account_num: u32, txid: &str, memo: &str) -> Result<(), E>;
     fn create_transaction(&mut self, details: &mut CreateTransaction)
         -> Result<TransactionMeta, E>;
     fn sign_transaction(&self, tx_detail_unsigned: &TransactionMeta) -> Result<TransactionMeta, E>;
     fn send_transaction(&mut self, tx_detail_signed: &TransactionMeta) -> Result<String, E>;
     fn broadcast_transaction(&mut self, tx_hex: &str) -> Result<String, E>;
-    fn get_receive_address(&self, addr_details: &Value) -> Result<AddressPointer, E>;
+    fn get_receive_address(&self, opt: &GetAddressOpt) -> Result<AddressPointer, E>;
     fn get_mnemonic(&self) -> Result<Mnemonic, E>;
     fn get_available_currencies(&self) -> Result<Value, E>;
     fn get_fee_estimates(&mut self) -> Result<Vec<FeeEstimate>, E>;
@@ -44,5 +44,5 @@ pub trait Session<E> {
     fn block_status(&self) -> Result<(u32, BEBlockHash), E>;
     fn tx_status(&self) -> Result<u64, E>;
     fn set_pin(&self, details: &PinSetDetails) -> Result<PinGetDetails, E>;
-    fn get_unspent_outputs(&self, details: &Value) -> Result<GetUnspentOutputs, E>;
+    fn get_unspent_outputs(&self, opt: &GetUnspentOpt) -> Result<GetUnspentOutputs, E>;
 }

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -26,7 +26,9 @@ pub trait Session<E> {
     fn get_subaccounts(&self) -> Result<Vec<AccountInfo>, E>;
     fn get_subaccount(&self, index: u32, num_confs: u32) -> Result<AccountInfo, E>;
     fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, E>;
+    /// Deprecated in favor of update_subaccount
     fn rename_subaccount(&mut self, opt: RenameAccountOpt) -> Result<(), E>;
+    fn update_subaccount(&mut self, opt: UpdateAccountOpt) -> Result<(), E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
     fn get_balance(&self, subaccount: u32, num_confs: u32) -> Result<Balances, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -28,7 +28,7 @@ pub trait Session<E> {
     fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
-    fn get_balance(&self, num_confs: u32, subaccount: u32) -> Result<Balances, E>;
+    fn get_balance(&self, subaccount: u32, num_confs: u32) -> Result<Balances, E>;
     fn set_transaction_memo(&self, account_num: u32, txid: &str, memo: &str) -> Result<(), E>;
     fn create_transaction(&mut self, details: &mut CreateTransaction)
         -> Result<TransactionMeta, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -28,7 +28,7 @@ pub trait Session<E> {
     fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
-    fn get_balance(&self, num_confs: u32, subaccount: Option<u32>) -> Result<Balances, E>;
+    fn get_balance(&self, num_confs: u32, subaccount: u32) -> Result<Balances, E>;
     fn set_transaction_memo(&self, account_num: u32, txid: &str, memo: &str) -> Result<(), E>;
     fn create_transaction(&mut self, details: &mut CreateTransaction)
         -> Result<TransactionMeta, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -23,8 +23,8 @@ pub trait Session<E> {
         pin: String,
         details: PinGetDetails,
     ) -> Result<Vec<Notification>, E>;
-    fn get_subaccounts(&self) -> Result<Vec<Subaccount>, E>;
-    fn get_subaccount(&self, index: u32, num_confs: u32) -> Result<Subaccount, E>;
+    fn get_subaccounts(&self) -> Result<Vec<AccountInfo>, E>;
+    fn get_subaccount(&self, index: u32, num_confs: u32) -> Result<AccountInfo, E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
     fn get_balance(&self, num_confs: u32, subaccount: Option<u32>) -> Result<Balances, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -26,6 +26,7 @@ pub trait Session<E> {
     fn get_subaccounts(&self) -> Result<Vec<AccountInfo>, E>;
     fn get_subaccount(&self, index: u32, num_confs: u32) -> Result<AccountInfo, E>;
     fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, E>;
+    fn rename_subaccount(&mut self, opt: RenameAccountOpt) -> Result<(), E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
     fn get_balance(&self, subaccount: u32, num_confs: u32) -> Result<Balances, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -25,6 +25,7 @@ pub trait Session<E> {
     ) -> Result<Vec<Notification>, E>;
     fn get_subaccounts(&self) -> Result<Vec<AccountInfo>, E>;
     fn get_subaccount(&self, index: u32, num_confs: u32) -> Result<AccountInfo, E>;
+    fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
     fn get_balance(&self, num_confs: u32, subaccount: Option<u32>) -> Result<Balances, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -35,7 +35,7 @@ pub trait Session<E> {
     fn send_transaction(&mut self, tx_detail_signed: &TransactionMeta) -> Result<String, E>;
     fn broadcast_transaction(&mut self, tx_hex: &str) -> Result<String, E>;
     fn get_receive_address(&self, addr_details: &Value) -> Result<AddressPointer, E>;
-    fn get_mnemonic(&self) -> Result<&Mnemonic, E>;
+    fn get_mnemonic(&self) -> Result<Mnemonic, E>;
     fn get_available_currencies(&self) -> Result<Value, E>;
     fn get_fee_estimates(&mut self) -> Result<Vec<FeeEstimate>, E>;
     fn get_settings(&self) -> Result<Settings, E>;

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -1,0 +1,163 @@
+use std::fmt;
+
+use log::debug;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use bitcoin::{Transaction, Script};
+use bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey};
+
+use gdk_common::wally::MasterBlindingKey;
+use gdk_common::{ElementsNetwork, Network, NetworkId};
+use gdk_common::model::{AddressPointer, CreateTransaction, TransactionMeta, Balances, GetTransactionsOpt};
+use gdk_common::be::{BEAddress, Utxos};
+
+use crate::error::Error;
+use crate::store::Store;
+
+lazy_static! {
+    static ref EC: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AccountNum(pub u32);
+
+pub struct Account {
+    account_num: AccountNum,
+    path: DerivationPath,
+    xpub: ExtendedPubKey,
+    xprv: ExtendedPrivKey,
+    network: Network,
+    store: Store,
+    // liquid only
+    master_blinding: Option<MasterBlindingKey>,
+}
+
+impl Account {
+    pub fn new(
+        network: Network,
+        master_xprv: &ExtendedPrivKey,
+        master_blinding: Option<MasterBlindingKey>,
+        store: Store,
+        account_num: AccountNum,
+    ) -> Result<Self, Error> {
+        let path = get_account_path(account_num, &network)?;
+
+        debug!("Using derivation path {} for account {}", path, account_num);
+
+        let xprv = master_xprv.derive_priv(&EC, &path)?;
+        let xpub = ExtendedPubKey::from_private(&EC, &xprv);
+
+        Ok(Self {
+            network,
+            account_num,
+            path,
+            xpub,
+            xprv,
+            store,
+            master_blinding,
+        })
+    }
+
+    fn derive_address(&self, is_change: bool, index: u32) -> Result<BEAddress, Error> {
+        unimplemented!()
+    }
+
+    pub fn get_address(&self) -> Result<AddressPointer, Error> {
+        unimplemented!()
+    }
+
+    pub fn list_tx(&self, opt: &GetTransactionsOpt) -> Result<Vec<TransactionMeta>, Error> {
+      unimplemented!()
+    }
+
+    pub fn utxos(&self) -> Result<Utxos, Error> {
+        unimplemented!()
+    }
+
+    pub fn balance(&self) -> Result<Balances, Error> {
+        unimplemented!()
+    }
+
+    pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {
+        unimplemented!()
+    }
+
+    fn internal_sign_bitcoin(
+        &self,
+        tx: &Transaction,
+        input_index: usize,
+        path: &DerivationPath,
+        value: u64,
+    ) -> (Script, Vec<Vec<u8>>) {
+        unimplemented!()
+    }
+
+    fn internal_sign_elements(
+        &self,
+        tx: &elements::Transaction,
+        input_index: usize,
+        derivation_path: &DerivationPath,
+        value: Value,
+    ) -> (Script, Vec<Vec<u8>>) {
+        unimplemented!()
+    }
+
+    pub fn sign(&self, request: &TransactionMeta) -> Result<TransactionMeta, Error> {
+        unimplemented!()
+    }
+
+    fn blind_tx(&self, tx: &mut elements::Transaction) -> Result<(), Error> {
+        unimplemented!()
+    }
+}
+
+impl fmt::Display for AccountNum {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl From<u32> for AccountNum {
+    fn from(num: u32) -> Self {
+        AccountNum(num)
+    }
+}
+impl From<usize> for AccountNum {
+    fn from(num: usize) -> Self {
+        AccountNum(num as u32)
+    }
+}
+impl Into<u32> for AccountNum {
+    fn into(self) -> u32 {
+        self.0
+    }
+}
+
+fn get_account_path(
+    account_num: AccountNum,
+    network: &Network,
+) -> Result<DerivationPath, Error> {
+    let coin_type = get_coin_type(network);
+    let purpose = 49; // P2SH-P2WPKH
+    // BIP44: m / purpose' / coin_type' / account' / change / address_index
+    let path: DerivationPath =
+        format!("m/{}'/{}'/{}'", purpose, coin_type, account_num).parse().unwrap();
+
+    Ok(path)
+}
+
+fn get_coin_type(network: &Network) -> u32 {
+    // coin_type = 0 bitcoin, 1 testnet, 1776 liquid bitcoin as defined in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+    // slip44 suggest 1 for every testnet, so we are using it also for regtest
+    match network.id() {
+        NetworkId::Bitcoin(bitcoin_network) => match bitcoin_network {
+            bitcoin::Network::Bitcoin => 0,
+            bitcoin::Network::Testnet => 1,
+            bitcoin::Network::Regtest => 1,
+        },
+        NetworkId::Elements(elements_network) => match elements_network {
+            ElementsNetwork::Liquid => 1776,
+            ElementsNetwork::ElementsRegtest => 1,
+        },
+    }
+}

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -766,7 +766,8 @@ pub fn create_tx(
             dummy_tx
                 .add_output(&out.address, out.satoshi, out.asset_tag.clone())
                 .map_err(|_| Error::InvalidAddress)?;
-            let estimated_fee = dummy_tx.estimated_fee(fee_rate, 0, account.script_type) + 3; // estimating 3 satoshi more as estimating less would later result in InsufficientFunds
+            // estimating 2 satoshi more as estimating less would later result in InsufficientFunds
+            let estimated_fee = dummy_tx.estimated_fee(fee_rate, 0, account.script_type) + 2;
             total_amount_utxos.checked_sub(estimated_fee).ok_or_else(|| Error::InsufficientFunds)?
         } else {
             total_amount_utxos

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -89,6 +89,8 @@ impl Account {
     }
 
     pub fn info(&self) -> Result<AccountInfo, Error> {
+        let name = self.store.read()?.get_account_name(self.account_num).cloned();
+
         let txs = self.list_tx(&GetTransactionsOpt {
             count: 1,
             ..Default::default()
@@ -97,10 +99,16 @@ impl Account {
         Ok(AccountInfo {
             account_num: self.account_num.into(),
             type_: "electrum".into(),
-            name: "Single sig wallet".into(),
+            name: name.unwrap_or("Single sig wallet".into()),
             has_transactions: !txs.is_empty(),
             satoshi: self.balance()?,
         })
+    }
+
+    pub fn set_name(&self, name: String) -> Result<(), Error> {
+        let mut store_write = self.store.write()?;
+        store_write.set_account_name(self.account_num, name.clone());
+        Ok(())
     }
 
     pub fn derive_address(&self, is_change: bool, index: u32) -> Result<BEAddress, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -134,7 +134,7 @@ impl Account {
     pub fn get_next_address(&self) -> Result<AddressPointer, Error> {
         let pointer = {
             let store = &mut self.store.write()?;
-            let acc_store = store.account_store_mut(self.account_num)?;
+            let acc_store = store.account_cache_mut(self.account_num)?;
             acc_store.indexes.external += 1;
             acc_store.indexes.external
         };
@@ -147,7 +147,7 @@ impl Account {
 
     pub fn list_tx(&self, opt: &GetTransactionsOpt) -> Result<Vec<TransactionMeta>, Error> {
         let store = self.store.read()?;
-        let acc_store = store.account_store(self.account_num)?;
+        let acc_store = store.account_cache(self.account_num)?;
 
         let mut txs = vec![];
         let mut my_txids: Vec<(&BETxid, &Option<u32>)> = acc_store.heights.iter().collect();
@@ -252,7 +252,7 @@ impl Account {
     pub fn utxos(&self) -> Result<Utxos, Error> {
         info!("start utxos");
         let store_read = self.store.read()?;
-        let acc_store = store_read.account_store(self.account_num)?;
+        let acc_store = store_read.account_cache(self.account_num)?;
 
         let mut utxos = vec![];
         let spent = self.spent()?;
@@ -339,7 +339,7 @@ impl Account {
 
     fn spent(&self) -> Result<HashSet<BEOutPoint>, Error> {
         let store_read = self.store.read()?;
-        let acc_store = store_read.account_store(self.account_num)?;
+        let acc_store = store_read.account_cache(self.account_num)?;
         let mut result = HashSet::new();
         for tx in acc_store.all_txs.values() {
             let outpoints: Vec<BEOutPoint> = match tx {
@@ -380,7 +380,7 @@ impl Account {
         info!("sign");
         let be_tx = BETransaction::deserialize(&hex::decode(&request.hex)?, self.network.id())?;
         let store_read = self.store.read()?;
-        let acc_store = store_read.account_store(self.account_num)?;
+        let acc_store = store_read.account_cache(self.account_num)?;
 
         let mut betx: TransactionMeta = match be_tx {
             BETransaction::Bitcoin(tx) => {
@@ -457,7 +457,7 @@ impl Account {
         drop(acc_store);
         drop(store_read);
         let mut store_write = self.store.write()?;
-        let mut acc_store = store_write.account_store_mut(self.account_num)?;
+        let mut acc_store = store_write.account_cache_mut(self.account_num)?;
 
         let changes_used = request.changes_used.unwrap_or(0);
         if changes_used > 0 {
@@ -478,7 +478,7 @@ impl Account {
 
     pub fn get_script_batch(&self, is_change: bool, batch: u32) -> Result<ScriptBatch, Error> {
         let store = self.store.read()?;
-        let acc_store = store.account_store(self.account_num)?;
+        let acc_store = store.account_cache(self.account_num)?;
 
         let mut result = ScriptBatch::default();
         result.cached = true;
@@ -735,7 +735,7 @@ pub fn create_tx(
 
     // STEP 2) add utxos until tx outputs are covered (including fees) or fail
     let store_read = account.store.read()?;
-    let acc_store = store_read.account_store(account.num())?;
+    let acc_store = store_read.account_cache(account.num())?;
     let mut used_utxo: HashSet<BEOutPoint> = HashSet::new();
     loop {
         let mut needs = tx.needs(
@@ -918,7 +918,7 @@ fn blind_tx(account: &Account, tx: &mut elements::Transaction) -> Result<(), Err
     info!("blind_tx {}", tx.txid());
 
     let store_read = account.store.read()?;
-    let acc_store = store_read.account_store(account.num())?;
+    let acc_store = store_read.account_cache(account.num())?;
 
     let mut input_assets = vec![];
     let mut input_abfs = vec![];

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -106,7 +106,7 @@ impl Account {
 
         Ok(AccountInfo {
             account_num: self.account_num.into(),
-            type_: "electrum".into(),
+            script_type: self.script_type,
             name: name.unwrap_or("Single sig wallet".into()),
             has_transactions: !txs.is_empty(),
             satoshi: self.balance()?,
@@ -540,6 +540,20 @@ impl AccountNum {
     pub fn as_u32(self) -> u32 {
         self.into()
     }
+}
+
+// Find the first unused account number for the given script type
+pub fn get_next_account_num(existing: HashSet<&AccountNum>, script_type: ScriptType) -> AccountNum {
+    let first_index = match script_type {
+        ScriptType::P2shP2wpkh => 0,
+        ScriptType::P2wpkh => 1,
+        ScriptType::P2pkh => 2,
+    };
+    (first_index..)
+        .step_by(NUM_RESERVED_ACCOUNT_TYPES as usize)
+        .map(AccountNum)
+        .find(|n| !existing.contains(n))
+        .unwrap()
 }
 
 fn get_account_derivation(

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -37,7 +37,7 @@ use crate::store::{Store, BATCH_SIZE};
 
 // The number of account types, including these reserved for future use.
 // Currently only 3 are used: P2SH-P2WPKH, P2WPKH and P2PKH
-const NUM_RESERVED_ACCOUNT_TYPES: u32 = 8;
+const NUM_RESERVED_ACCOUNT_TYPES: u32 = 16;
 
 lazy_static! {
     static ref EC: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
@@ -1160,17 +1160,17 @@ mod test {
         test_derivation(2, ScriptType::P2pkh, "m/44'/1'/0'");
 
         // reserved for future use, currently rejected
-        for n in 3..=7 {
+        for n in 3..=15 {
             test_derivation_fails(n);
         }
 
-        test_derivation(8, ScriptType::P2shP2wpkh, "m/49'/1'/1'");
-        test_derivation(9, ScriptType::P2wpkh, "m/84'/1'/1'");
-        test_derivation(10, ScriptType::P2pkh, "m/44'/1'/1'");
-        test_derivation_fails(11);
+        test_derivation(16, ScriptType::P2shP2wpkh, "m/49'/1'/1'");
+        test_derivation(17, ScriptType::P2wpkh, "m/84'/1'/1'");
+        test_derivation(18, ScriptType::P2pkh, "m/44'/1'/1'");
+        test_derivation_fails(19);
 
-        test_derivation(80, ScriptType::P2shP2wpkh, "m/49'/1'/10'");
-        test_derivation(81, ScriptType::P2wpkh, "m/84'/1'/10'");
-        test_derivation(82, ScriptType::P2pkh, "m/44'/1'/10'");
+        test_derivation(160, ScriptType::P2shP2wpkh, "m/49'/1'/10'");
+        test_derivation(161, ScriptType::P2wpkh, "m/84'/1'/10'");
+        test_derivation(162, ScriptType::P2pkh, "m/44'/1'/10'");
     }
 }

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -104,9 +104,9 @@ impl Account {
         })
     }
 
-    pub fn set_name(&self, name: String) -> Result<(), Error> {
+    pub fn set_name(&self, name: &str) -> Result<(), Error> {
         let mut store_write = self.store.write()?;
-        store_write.set_account_name(self.account_num, name.clone());
+        store_write.set_account_name(self.account_num, name.to_string());
         Ok(())
     }
 

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -178,7 +178,7 @@ impl Account {
                     });
                 }
             }
-            let memo = store.get_memo(self.account_num, tx_id).cloned();
+            let memo = store.get_memo(tx_id).cloned();
 
             let create_transaction = CreateTransaction {
                 addressees,
@@ -494,7 +494,7 @@ impl Account {
 
         if let Some(memo) = request.create_transaction.as_ref().and_then(|c| c.memo.as_ref()) {
             let txid = BETxid::from_hex(&betx.txid, self.network.id())?;
-            store_write.insert_memo(self.account_num, txid, memo)?;
+            store_write.insert_memo(txid, memo)?;
         }
 
         Ok(betx)

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -43,7 +43,7 @@ lazy_static! {
     static ref EC: secp256k1::Secp256k1<secp256k1::All> = secp256k1::Secp256k1::new();
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct AccountNum(pub u32);
 
 pub struct Account {

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -366,6 +366,9 @@ impl Account {
     }
 
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {
+        if request.subaccount != self.account_num {
+            return Err(Error::InvalidSubaccount(request.subaccount));
+        }
         create_tx(self, request)
     }
 
@@ -684,12 +687,6 @@ pub fn create_tx(
     request: &mut CreateTransaction,
 ) -> Result<TransactionMeta, Error> {
     info!("create_tx {:?}", request);
-
-    // @shesek XXX how to handle missing subaccount/create_transaction?
-    let subaccount = request.subaccount.unwrap_or(0);
-    if subaccount != account.num() {
-        return Err(Error::InvalidSubaccount(subaccount));
-    }
 
     let network = &account.network;
 

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -45,14 +45,14 @@ lazy_static! {
 pub struct Account {
     account_num: u32,
     script_type: ScriptType,
-    path: DerivationPath,
-    xpub: ExtendedPubKey,
     xprv: ExtendedPrivKey,
     chains: [ExtendedPubKey; 2],
     network: Network,
     store: Store,
     // elements only
     master_blinding: Option<MasterBlindingKey>,
+    _path: DerivationPath,
+    _xpub: ExtendedPubKey,
 }
 
 impl Account {
@@ -79,12 +79,13 @@ impl Account {
             network,
             account_num,
             script_type,
-            path,
-            xpub,
             xprv,
             chains,
             store,
             master_blinding,
+            // currently unused, but seems useful to have around
+            _path: path,
+            _xpub: xpub,
         })
     }
 

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -1,23 +1,35 @@
 use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::convert::TryInto;
 use std::fmt;
+use std::str::FromStr;
 
 use log::{debug, info, trace};
+use rand::Rng;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
+use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::{self, Message};
+use bitcoin::util::address::Payload;
+use bitcoin::util::bip143::SigHashCache;
 use bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey};
-use bitcoin::{Address, PublicKey, Script, Transaction, Txid};
+use bitcoin::{PublicKey, SigHashType};
+use elements::confidential::Value;
 
-use gdk_common::wally::{asset_blinding_key_to_ec_private_key, ec_public_key_from_private_key};
+use gdk_common::wally::{
+    asset_blinding_key_to_ec_private_key, ec_public_key_from_private_key, MasterBlindingKey,
+};
 
-use gdk_common::be::{BEAddress, BEScript, BEScriptConvert, ScriptBatch, Utxos};
+use gdk_common::be::{
+    BEAddress, BEOutPoint, BEScript, BEScriptConvert, BETransaction, BETxid, ScriptBatch, UTXOInfo,
+    Utxos, DUST_VALUE,
+};
 use gdk_common::error::fn_err;
 use gdk_common::model::{
     AddressAmount, AddressPointer, Balances, CreateTransaction, GetTransactionsOpt,
     SPVVerifyResult, TransactionMeta,
 };
-use gdk_common::scripts::p2shwpkh_script;
-use gdk_common::wally::MasterBlindingKey;
+use gdk_common::scripts::{p2pkh_script, p2shwpkh_script, p2shwpkh_script_sig};
 use gdk_common::{ElementsNetwork, Network, NetworkId};
 
 use crate::error::Error;
@@ -38,7 +50,7 @@ pub struct Account {
     chains: [ExtendedPubKey; 2],
     network: Network,
     store: Store,
-    // liquid only
+    // elements only
     master_blinding: Option<MasterBlindingKey>,
 }
 
@@ -81,16 +93,16 @@ impl Account {
         let derived = chain_xpub.ckd_pub(&EC, index.into())?;
 
         match self.network.id() {
-            NetworkId::Bitcoin(network) => {
-                Ok(BEAddress::Bitcoin(Address::p2shwpkh(&derived.public_key, network).unwrap()))
-            }
+            NetworkId::Bitcoin(network) => Ok(BEAddress::Bitcoin(
+                bitcoin::Address::p2shwpkh(&derived.public_key, network).unwrap(),
+            )),
             NetworkId::Elements(network) => {
                 let master_blinding_key = self
                     .master_blinding
                     .as_ref()
                     .expect("we are in elements but master blinding is None");
 
-                let address = liquid_address(&derived.public_key, master_blinding_key, network);
+                let address = elements_address(&derived.public_key, master_blinding_key, network);
                 Ok(BEAddress::Elements(address))
             }
         }
@@ -111,47 +123,336 @@ impl Account {
     }
 
     pub fn list_tx(&self, opt: &GetTransactionsOpt) -> Result<Vec<TransactionMeta>, Error> {
-        unimplemented!()
+        let store = self.store.read()?;
+        let acc_store = store.account_store(self.account_num)?;
+
+        let mut txs = vec![];
+        let mut my_txids: Vec<(&BETxid, &Option<u32>)> = acc_store.heights.iter().collect();
+        my_txids.sort_by(|a, b| {
+            let height_cmp = b.1.unwrap_or(std::u32::MAX).cmp(&a.1.unwrap_or(std::u32::MAX));
+            match height_cmp {
+                Ordering::Equal => b.0.cmp(a.0),
+                h @ _ => h,
+            }
+        });
+
+        for (tx_id, height) in my_txids.iter().skip(opt.first).take(opt.count) {
+            trace!("tx_id {}", tx_id);
+
+            let tx = acc_store
+                .all_txs
+                .get(*tx_id)
+                .ok_or_else(fn_err(&format!("list_tx no tx {}", tx_id)))?;
+            let header = height.map(|h| store.cache.headers.get(&h)).flatten();
+            trace!("tx_id {} header {:?}", tx_id, header);
+            let mut addressees = vec![];
+            for i in 0..tx.output_len() as u32 {
+                let script = tx.output_script(i);
+                if !script.is_empty() && !acc_store.paths.contains_key(&script) {
+                    let address = tx.output_address(i, self.network.id());
+                    trace!("tx_id {}:{} not my script, address {:?}", tx_id, i, address);
+                    addressees.push(AddressAmount {
+                        address: address.unwrap_or_else(|| "".to_string()),
+                        satoshi: 0, // apparently not needed in list_tx addressees
+                        asset_tag: None,
+                    });
+                }
+            }
+            // @shesek FIXME per-account memos
+            let memo = store.get_memo(tx_id).map(|s| s.to_string());
+
+            let create_transaction = CreateTransaction {
+                addressees,
+                memo,
+                ..Default::default()
+            };
+
+            let fee = tx.fee(
+                &acc_store.all_txs,
+                &acc_store.unblinded,
+                &self.network.policy_asset().ok(),
+            )?;
+            trace!("tx_id {} fee {}", tx_id, fee);
+
+            let satoshi =
+                tx.my_balance_changes(&acc_store.all_txs, &acc_store.paths, &acc_store.unblinded);
+            trace!("tx_id {} balances {:?}", tx_id, satoshi);
+
+            // We define an incoming txs if there are more assets received by the wallet than spent
+            // when they are equal it's an outgoing tx because the special asset liquid BTC
+            // is negative due to the fee being paid
+            // TODO how do we label issuance tx?
+            let negatives = satoshi.iter().filter(|(_, v)| **v < 0).count();
+            let positives = satoshi.iter().filter(|(_, v)| **v > 0).count();
+            let (type_, user_signed) = match (
+                positives > negatives,
+                tx.is_redeposit(&acc_store.paths, &acc_store.all_txs),
+            ) {
+                (_, true) => ("redeposit", true),
+                (true, false) => ("incoming", false),
+                (false, false) => ("outgoing", true),
+            };
+
+            let spv_verified = if self.network.spv_enabled.unwrap_or(false) {
+                store.spv_verification_status(tx_id)
+            } else {
+                SPVVerifyResult::Disabled
+            };
+
+            trace!(
+                "tx_id {} type {} user_signed {} spv_verified {:?}",
+                tx_id,
+                type_,
+                user_signed,
+                spv_verified
+            );
+
+            let tx_meta = TransactionMeta::new(
+                tx.clone(),
+                **height,
+                header.map(|h| h.time()),
+                satoshi,
+                fee,
+                self.network.id().get_bitcoin_network().unwrap_or(bitcoin::Network::Bitcoin),
+                type_.to_string(),
+                create_transaction,
+                user_signed,
+                spv_verified,
+            );
+
+            txs.push(tx_meta);
+        }
+        info!("list_tx {:?}", txs.iter().map(|e| &e.txid).collect::<Vec<&String>>());
+
+        Ok(txs)
     }
 
     pub fn utxos(&self) -> Result<Utxos, Error> {
-        unimplemented!()
+        info!("start utxos");
+        let store_read = self.store.read()?;
+        let acc_store = store_read.account_store(self.account_num)?;
+
+        let mut utxos = vec![];
+        let spent = self.spent()?;
+        for (tx_id, height) in acc_store.heights.iter() {
+            let tx = acc_store
+                .all_txs
+                .get(tx_id)
+                .ok_or_else(fn_err(&format!("utxos no tx {}", tx_id)))?;
+            let tx_utxos: Vec<(BEOutPoint, UTXOInfo)> = match tx {
+                BETransaction::Bitcoin(tx) => tx
+                    .output
+                    .clone()
+                    .into_iter()
+                    .enumerate()
+                    .filter(|(_, output)| output.value > DUST_VALUE)
+                    .map(|(vout, output)| (BEOutPoint::new_bitcoin(tx.txid(), vout as u32), output))
+                    .filter_map(|(vout, output)| {
+                        acc_store
+                            .paths
+                            .get(&(&output.script_pubkey).into())
+                            .map(|path| (vout, output, path))
+                    })
+                    .filter(|(outpoint, _, _)| !spent.contains(&outpoint))
+                    .map(|(outpoint, output, path)| {
+                        (
+                            outpoint,
+                            UTXOInfo::new(
+                                "btc".to_string(),
+                                output.value,
+                                output.script_pubkey.into(),
+                                height.clone(),
+                                path.clone(),
+                            ),
+                        )
+                    })
+                    .collect(),
+                BETransaction::Elements(tx) => {
+                    let policy_asset = self.network.policy_asset_id()?;
+                    tx.output
+                        .clone()
+                        .into_iter()
+                        .enumerate()
+                        .map(|(vout, output)| {
+                            (BEOutPoint::new_elements(tx.txid(), vout as u32), output)
+                        })
+                        .filter_map(|(vout, output)| {
+                            acc_store
+                                .paths
+                                .get(&(&output.script_pubkey).into())
+                                .map(|path| (vout, output, path))
+                        })
+                        .filter(|(outpoint, _, _)| !spent.contains(&outpoint))
+                        .filter_map(|(outpoint, output, path)| {
+                            if let BEOutPoint::Elements(el_outpoint) = outpoint {
+                                if let Some(unblinded) = acc_store.unblinded.get(&el_outpoint) {
+                                    if unblinded.value < DUST_VALUE
+                                        && unblinded.asset == policy_asset
+                                    {
+                                        return None;
+                                    }
+                                    return Some((
+                                        outpoint,
+                                        UTXOInfo::new(
+                                            unblinded.asset_hex(),
+                                            unblinded.value,
+                                            output.script_pubkey.into(),
+                                            height.clone(),
+                                            path.clone(),
+                                        ),
+                                    ));
+                                }
+                            }
+                            None
+                        })
+                        .collect()
+                }
+            };
+            utxos.extend(tx_utxos);
+        }
+        utxos.sort_by(|a, b| (b.1).value.cmp(&(a.1).value));
+
+        Ok(utxos)
+    }
+
+    fn spent(&self) -> Result<HashSet<BEOutPoint>, Error> {
+        let store_read = self.store.read()?;
+        let acc_store = store_read.account_store(self.account_num)?;
+        let mut result = HashSet::new();
+        for tx in acc_store.all_txs.values() {
+            let outpoints: Vec<BEOutPoint> = match tx {
+                BETransaction::Bitcoin(tx) => {
+                    tx.input.iter().map(|i| BEOutPoint::Bitcoin(i.previous_output)).collect()
+                }
+                BETransaction::Elements(tx) => {
+                    tx.input.iter().map(|i| BEOutPoint::Elements(i.previous_output)).collect()
+                }
+            };
+            result.extend(outpoints.into_iter());
+        }
+        Ok(result)
     }
 
     pub fn balance(&self) -> Result<Balances, Error> {
-        unimplemented!()
+        info!("start balance");
+        let mut result = HashMap::new();
+        match self.network.id() {
+            NetworkId::Bitcoin(_) => result.entry("btc".to_string()).or_insert(0),
+            NetworkId::Elements(_) => {
+                result.entry(self.network.policy_asset.as_ref().unwrap().clone()).or_insert(0)
+            }
+        };
+        for (_, info) in self.utxos()?.iter() {
+            *result.entry(info.asset.clone()).or_default() += info.value as i64;
+        }
+        Ok(result)
     }
 
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {
-        unimplemented!()
+        create_tx(self, request)
     }
 
-    fn internal_sign_bitcoin(
-        &self,
-        tx: &Transaction,
-        input_index: usize,
-        path: &DerivationPath,
-        value: u64,
-    ) -> (Script, Vec<Vec<u8>>) {
-        unimplemented!()
-    }
-
-    fn internal_sign_elements(
-        &self,
-        tx: &elements::Transaction,
-        input_index: usize,
-        derivation_path: &DerivationPath,
-        value: Value,
-    ) -> (Script, Vec<Vec<u8>>) {
-        unimplemented!()
-    }
-
+    // TODO when we can serialize psbt
+    //pub fn sign(&self, psbt: PartiallySignedTransaction) -> Result<PartiallySignedTransaction, Error> { Err(Error::Generic("NotImplemented".to_string())) }
     pub fn sign(&self, request: &TransactionMeta) -> Result<TransactionMeta, Error> {
-        unimplemented!()
-    }
+        info!("sign");
+        let be_tx = BETransaction::deserialize(&hex::decode(&request.hex)?, self.network.id())?;
+        let store_read = self.store.read()?;
+        let acc_store = store_read.account_store(self.account_num)?;
 
-    fn blind_tx(&self, tx: &mut elements::Transaction) -> Result<(), Error> {
-        unimplemented!()
+        let mut betx: TransactionMeta = match be_tx {
+            BETransaction::Bitcoin(tx) => {
+                let mut out_tx = tx.clone();
+
+                for i in 0..tx.input.len() {
+                    let prev_output = tx.input[i].previous_output;
+                    info!("input#{} prev_output:{:?}", i, prev_output);
+                    let prev_tx = acc_store.get_bitcoin_tx(&prev_output.txid)?;
+                    let out = prev_tx.output[prev_output.vout as usize].clone();
+                    let derivation_path: DerivationPath = acc_store
+                        .paths
+                        .get(&out.script_pubkey.into())
+                        .ok_or_else(|| Error::Generic("can't find derivation path".into()))?
+                        .clone();
+                    info!(
+                        "input#{} prev_output:{:?} derivation_path:{:?}",
+                        i, prev_output, derivation_path
+                    );
+
+                    let (script_sig, witness) =
+                        internal_sign_bitcoin(&tx, i, &self.xprv, &derivation_path, out.value);
+
+                    out_tx.input[i].script_sig = script_sig;
+                    out_tx.input[i].witness = witness;
+                }
+                let tx = BETransaction::Bitcoin(out_tx);
+                info!(
+                    "transaction final size is {} bytes and {} vbytes",
+                    tx.serialize().len(),
+                    tx.get_weight() / 4
+                );
+                info!("FINALTX inputs:{} outputs:{}", tx.input_len(), tx.output_len());
+                tx.into()
+            }
+            BETransaction::Elements(mut tx) => {
+                blind_tx(self, &mut tx)?;
+
+                for i in 0..tx.input.len() {
+                    let prev_output = tx.input[i].previous_output;
+                    info!("input#{} prev_output:{:?}", i, prev_output);
+                    let prev_tx = acc_store.get_liquid_tx(&prev_output.txid)?;
+                    let out = prev_tx.output[prev_output.vout as usize].clone();
+                    let derivation_path: DerivationPath = acc_store
+                        .paths
+                        .get(&out.script_pubkey.into())
+                        .ok_or_else(|| Error::Generic("can't find derivation path".into()))?
+                        .clone();
+
+                    let (script_sig, witness) =
+                        internal_sign_elements(&tx, i, &self.xprv, &derivation_path, out.value);
+
+                    tx.input[i].script_sig = script_sig;
+                    tx.input[i].witness.script_witness = witness;
+                }
+
+                let fee: u64 =
+                    tx.output.iter().filter(|o| o.is_fee()).map(|o| o.minimum_value()).sum();
+                let tx = BETransaction::Elements(tx);
+                info!(
+                    "transaction final size is {} bytes and {} vbytes and fee is {}",
+                    tx.serialize().len(),
+                    tx.get_weight() / 4,
+                    fee
+                );
+                info!("FINALTX inputs:{} outputs:{}", tx.input_len(), tx.output_len());
+                tx.into()
+            }
+        };
+
+        betx.fee = request.fee;
+        betx.create_transaction = request.create_transaction.clone();
+
+        drop(acc_store);
+        drop(store_read);
+        let mut store_write = self.store.write()?;
+        let mut acc_store = store_write.account_store_mut(self.account_num)?;
+
+        let changes_used = request.changes_used.unwrap_or(0);
+        if changes_used > 0 {
+            info!("tx used {} changes", changes_used);
+            // The next sync would update the internal index but we increment the internal index also
+            // here after sign so that if we immediately create another tx we are not reusing addresses
+            // This implies signing multiple times without broadcasting leads to gaps in the internal chain
+            acc_store.indexes.internal += changes_used;
+        }
+
+        if let Some(memo) = request.create_transaction.as_ref().and_then(|c| c.memo.as_ref()) {
+            // @shesek TODO per-account memos
+            let txid = BETxid::from_hex(&betx.txid, self.network.id())?;
+            store_write.insert_memo(txid, memo)?;
+        }
+
+        Ok(betx)
     }
 
     pub fn get_script_batch(&self, is_change: bool, batch: u32) -> Result<ScriptBatch, Error> {
@@ -160,8 +461,6 @@ impl Account {
 
         let mut result = ScriptBatch::default();
         result.cached = true;
-
-        let chain_xpub = &self.chains[is_change as usize];
 
         let start = batch * BATCH_SIZE;
         let end = start + BATCH_SIZE;
@@ -207,13 +506,10 @@ impl AccountNum {
     }
 }
 
-fn get_account_path(
-    account_num: AccountNum,
-    network: &Network,
-) -> Result<DerivationPath, Error> {
+fn get_account_path(account_num: AccountNum, network: &Network) -> Result<DerivationPath, Error> {
     let coin_type = get_coin_type(network);
     let purpose = 49; // P2SH-P2WPKH
-    // BIP44: m / purpose' / coin_type' / account' / change / address_index
+                      // BIP44: m / purpose' / coin_type' / account' / change / address_index
     let path: DerivationPath =
         format!("m/{}'/{}'/{}'", purpose, coin_type, account_num).parse().unwrap();
 
@@ -237,7 +533,7 @@ fn get_coin_type(network: &Network) -> u32 {
     }
 }
 
-fn liquid_address(
+fn elements_address(
     public_key: &PublicKey,
     master_blinding_key: &MasterBlindingKey,
     net: ElementsNetwork,
@@ -246,10 +542,494 @@ fn liquid_address(
     let blinding_key = asset_blinding_key_to_ec_private_key(&master_blinding_key, &script);
     let blinding_pub = ec_public_key_from_private_key(blinding_key);
 
-    let addr_params = match net {
-        ElementsNetwork::Liquid => &elements::AddressParams::LIQUID,
-        ElementsNetwork::ElementsRegtest => &elements::AddressParams::ELEMENTS,
-    };
+    let addr_params = elements_address_params(net);
 
     elements::Address::p2shwpkh(public_key, Some(blinding_pub), addr_params)
+}
+
+fn elements_address_params(net: ElementsNetwork) -> &'static elements::AddressParams {
+    match net {
+        ElementsNetwork::Liquid => &elements::AddressParams::LIQUID,
+        ElementsNetwork::ElementsRegtest => &elements::AddressParams::ELEMENTS,
+    }
+}
+
+fn random32() -> Vec<u8> {
+    rand::thread_rng().gen::<[u8; 32]>().to_vec()
+}
+
+#[allow(clippy::cognitive_complexity)]
+pub fn create_tx(
+    account: &Account,
+    request: &mut CreateTransaction,
+) -> Result<TransactionMeta, Error> {
+    info!("create_tx {:?}", request);
+    let network = &account.network;
+
+    // TODO put checks into CreateTransaction::validate, add check asset_tag are valid asset hex
+    // eagerly check for address validity
+    for address in request.addressees.iter().map(|a| &a.address) {
+        match network.id() {
+            NetworkId::Bitcoin(network) => {
+                if let Ok(address) = bitcoin::Address::from_str(address) {
+                    info!("address.network:{} network:{}", address.network, network);
+                    if address.network == network
+                        || (address.network == bitcoin::Network::Testnet
+                            && network == bitcoin::Network::Regtest)
+                    {
+                        continue;
+                    }
+                    if let Payload::WitnessProgram {
+                        version: v,
+                        program: _p,
+                    } = &address.payload
+                    {
+                        // Do not support segwit greater than v0
+                        if v.to_u8() > 0 {
+                            return Err(Error::InvalidAddress);
+                        }
+                    }
+                }
+                return Err(Error::InvalidAddress);
+            }
+            NetworkId::Elements(network) => {
+                if let Ok(address) = elements::Address::from_str(address) {
+                    info!(
+                        "address.params:{:?} address_params(network):{:?}",
+                        address.params,
+                        elements_address_params(network)
+                    );
+                    if address.params == elements_address_params(network) {
+                        continue;
+                    }
+                }
+                return Err(Error::InvalidAddress);
+            }
+        }
+    }
+
+    if request.addressees.is_empty() {
+        return Err(Error::EmptyAddressees);
+    }
+
+    let subaccount = request.subaccount.unwrap_or(0);
+    if subaccount != 0 {
+        return Err(Error::InvalidSubaccount(subaccount));
+    }
+
+    if !request.previous_transaction.is_empty() {
+        return Err(Error::Generic("bump not supported".into()));
+    }
+
+    let send_all = request.send_all.unwrap_or(false);
+    request.send_all = Some(send_all); // accept default false, but always return the value
+    if !send_all && request.addressees.iter().any(|a| a.satoshi == 0) {
+        return Err(Error::InvalidAmount);
+    }
+
+    if !send_all {
+        for address_amount in request.addressees.iter() {
+            if address_amount.satoshi <= DUST_VALUE {
+                match network.id() {
+                    NetworkId::Bitcoin(_) => return Err(Error::InvalidAmount),
+                    NetworkId::Elements(_) => {
+                        if address_amount.asset_tag == network.policy_asset {
+                            // we apply dust rules for liquid bitcoin as elements do
+                            return Err(Error::InvalidAmount);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if let NetworkId::Elements(_) = network.id() {
+        if request.addressees.iter().any(|a| a.asset_tag.is_none()) {
+            return Err(Error::AssetEmpty);
+        }
+    }
+
+    // convert from satoshi/kbyte to satoshi/byte
+    let default_value = match network.id() {
+        NetworkId::Bitcoin(_) => 1000,
+        NetworkId::Elements(_) => 100,
+    };
+    let fee_rate = (request.fee_rate.unwrap_or(default_value) as f64) / 1000.0;
+    info!("target fee_rate {:?} satoshi/byte", fee_rate);
+
+    let utxos = match &request.utxos {
+        None => account.utxos()?,
+        Some(utxos) => utxos.try_into()?,
+    };
+    info!("utxos len:{} utxos:{:?}", utxos.len(), utxos);
+
+    if send_all {
+        // send_all works by creating a dummy tx with all utxos, estimate the fee and set the
+        // sending amount to `total_amount_utxos - estimated_fee`
+        info!("send_all calculating total_amount");
+        if request.addressees.len() != 1 {
+            return Err(Error::SendAll);
+        }
+        let asset = request.addressees[0].asset_tag.as_deref().unwrap_or("btc");
+        let all_utxos: Vec<&(BEOutPoint, UTXOInfo)> =
+            utxos.iter().filter(|(_, i)| i.asset == asset).collect();
+        let total_amount_utxos: u64 = all_utxos.iter().map(|(_, i)| i.value).sum();
+
+        let to_send = if asset == "btc" || Some(asset.to_string()) == network.policy_asset {
+            let mut dummy_tx = BETransaction::new(network.id());
+            for utxo in all_utxos.iter() {
+                dummy_tx.add_input(utxo.0.clone());
+            }
+            let out = &request.addressees[0]; // safe because we checked we have exactly one recipient
+            dummy_tx
+                .add_output(&out.address, out.satoshi, out.asset_tag.clone())
+                .map_err(|_| Error::InvalidAddress)?;
+            let estimated_fee = dummy_tx.estimated_fee(fee_rate, 0) + 3; // estimating 3 satoshi more as estimating less would later result in InsufficientFunds
+            total_amount_utxos.checked_sub(estimated_fee).ok_or_else(|| Error::InsufficientFunds)?
+        } else {
+            total_amount_utxos
+        };
+
+        info!("send_all asset: {} to_send:{}", asset, to_send);
+
+        request.addressees[0].satoshi = to_send;
+    }
+
+    let mut tx = BETransaction::new(network.id());
+    // transaction is created in 3 steps:
+    // 1) adding requested outputs to tx outputs
+    // 2) adding enough utxso to inputs such that tx outputs and estimated fees are covered
+    // 3) adding change(s)
+
+    // STEP 1) add the outputs requested for this transactions
+    for out in request.addressees.iter() {
+        tx.add_output(&out.address, out.satoshi, out.asset_tag.clone())
+            .map_err(|_| Error::InvalidAddress)?;
+    }
+
+    // STEP 2) add utxos until tx outputs are covered (including fees) or fail
+    let store_read = account.store.read()?;
+    let acc_store = store_read.account_store(account.num())?;
+    let mut used_utxo: HashSet<BEOutPoint> = HashSet::new();
+    loop {
+        let mut needs = tx.needs(
+            fee_rate,
+            send_all,
+            network.policy_asset.clone(),
+            &acc_store.all_txs,
+            &acc_store.unblinded,
+        ); // Vec<(asset_string, satoshi)  "policy asset" is last, in bitcoin asset_string="btc" and max 1 element
+        info!("needs: {:?}", needs);
+        if needs.is_empty() {
+            // SUCCESS tx doesn't need other inputs
+            break;
+        }
+        let current_need = needs.pop().unwrap(); // safe to unwrap just checked it's not empty
+
+        // taking only utxos of current asset considered, filters also utxos used in this loop
+        let mut asset_utxos: Vec<&(BEOutPoint, UTXOInfo)> = utxos
+            .iter()
+            .filter(|(o, i)| i.asset == current_need.asset && !used_utxo.contains(o))
+            .collect();
+
+        // sort by biggest utxo, random maybe another option, but it should be deterministically random (purely random breaks send_all algorithm)
+        asset_utxos.sort_by(|a, b| (a.1).value.cmp(&(b.1).value));
+        let utxo = asset_utxos.pop().ok_or(Error::InsufficientFunds)?;
+
+        match network.id() {
+            NetworkId::Bitcoin(_) => {
+                // UTXO with same script must be spent together
+                for other_utxo in utxos.iter() {
+                    if (other_utxo.1).script == (utxo.1).script {
+                        used_utxo.insert(other_utxo.0.clone());
+                        tx.add_input(other_utxo.0.clone());
+                    }
+                }
+            }
+            NetworkId::Elements(_) => {
+                // Don't spend same script together in liquid. This would allow an attacker
+                // to cheaply send assets without value to the target, which will have to
+                // waste fees for the extra tx inputs and (eventually) outputs.
+                // While blinded address are required and not public knowledge,
+                // they are still available to whom transacted with us in the past
+                used_utxo.insert(utxo.0.clone());
+                tx.add_input(utxo.0.clone());
+            }
+        }
+    }
+
+    // STEP 3) adding change(s)
+    let estimated_fee = tx.estimated_fee(
+        fee_rate,
+        tx.estimated_changes(send_all, &acc_store.all_txs, &acc_store.unblinded),
+    );
+    let changes = tx.changes(
+        estimated_fee,
+        network.policy_asset.clone(),
+        &acc_store.all_txs,
+        &acc_store.unblinded,
+    ); // Vec<Change> asset, value
+    for (i, change) in changes.iter().enumerate() {
+        let change_index = acc_store.indexes.internal + i as u32 + 1;
+        let change_address = account.derive_address(true, change_index)?.to_string();
+        info!(
+            "adding change to {} of {} asset {:?}",
+            &change_address, change.satoshi, change.asset
+        );
+        tx.add_output(&change_address, change.satoshi, Some(change.asset.clone()))?;
+    }
+
+    // randomize inputs and outputs, BIP69 has been rejected because lacks wallets adoption
+    tx.scramble();
+
+    let policy_asset = network.policy_asset().ok();
+    let fee_val = tx.fee(&acc_store.all_txs, &acc_store.unblinded, &policy_asset)?; // recompute exact fee_val from built tx
+    tx.add_fee_if_elements(fee_val, &policy_asset)?;
+
+    info!("created tx fee {:?}", fee_val);
+
+    let mut satoshi =
+        tx.my_balance_changes(&acc_store.all_txs, &acc_store.paths, &acc_store.unblinded);
+
+    for (_, v) in satoshi.iter_mut() {
+        *v = v.abs();
+    }
+
+    let mut created_tx = TransactionMeta::new(
+        tx,
+        None,
+        None,
+        satoshi,
+        fee_val,
+        network.id().get_bitcoin_network().unwrap_or(bitcoin::Network::Bitcoin),
+        "outgoing".to_string(),
+        request.clone(),
+        true,
+        SPVVerifyResult::InProgress,
+    );
+    created_tx.changes_used = Some(changes.len() as u32);
+    info!("returning: {:?}", created_tx);
+
+    Ok(created_tx)
+}
+
+fn internal_sign_bitcoin(
+    tx: &bitcoin::Transaction,
+    input_index: usize,
+    xprv: &ExtendedPrivKey,
+    path: &DerivationPath,
+    value: u64,
+) -> (bitcoin::Script, Vec<Vec<u8>>) {
+    let xprv = xprv.derive_priv(&EC, &path).unwrap();
+    let private_key = &xprv.private_key;
+    let public_key = &PublicKey::from_private_key(&EC, private_key);
+    let witness_script = p2pkh_script(public_key);
+
+    let hash =
+        SigHashCache::new(tx).signature_hash(input_index, &witness_script, value, SigHashType::All);
+
+    let message = Message::from_slice(&hash.into_inner()[..]).unwrap();
+    let signature = EC.sign(&message, &private_key.key);
+
+    let mut signature = signature.serialize_der().to_vec();
+    signature.push(SigHashType::All as u8);
+
+    let script_sig = p2shwpkh_script_sig(public_key);
+    let witness = vec![signature, public_key.to_bytes()];
+    info!(
+        "added size len: script_sig:{} witness:{}",
+        script_sig.len(),
+        witness.iter().map(|v| v.len()).sum::<usize>()
+    );
+
+    (script_sig, witness)
+}
+
+fn internal_sign_elements(
+    tx: &elements::Transaction,
+    input_index: usize,
+    xprv: &ExtendedPrivKey,
+    path: &DerivationPath,
+    value: Value,
+) -> (elements::Script, Vec<Vec<u8>>) {
+    use gdk_common::wally::tx_get_elements_signature_hash;
+
+    let xprv = xprv.derive_priv(&EC, &path).unwrap();
+    let private_key = &xprv.private_key;
+    let public_key = &PublicKey::from_private_key(&EC, private_key);
+
+    let script_code = p2pkh_script(public_key).into_elements();
+    let sighash = tx_get_elements_signature_hash(
+        &tx,
+        input_index,
+        &script_code,
+        &value,
+        SigHashType::All.as_u32(),
+        true, // segwit
+    );
+    let message = secp256k1::Message::from_slice(&sighash[..]).unwrap();
+    let signature = EC.sign(&message, &private_key.key);
+    let mut signature = signature.serialize_der().to_vec();
+    signature.push(SigHashType::All as u8);
+
+    let script_sig = p2shwpkh_script_sig(public_key).into_elements();
+    let witness = vec![signature, public_key.to_bytes()];
+    info!(
+        "added size len: script_sig:{} witness:{}",
+        script_sig.len(),
+        witness.iter().map(|v| v.len()).sum::<usize>()
+    );
+    (script_sig, witness)
+}
+
+fn blind_tx(account: &Account, tx: &mut elements::Transaction) -> Result<(), Error> {
+    use elements::confidential::{Asset, Nonce};
+    use gdk_common::wally::{
+        asset_final_vbf, asset_generator_from_bytes, asset_rangeproof, asset_surjectionproof,
+        asset_value_commitment,
+    };
+
+    info!("blind_tx {}", tx.txid());
+
+    let store_read = account.store.read()?;
+    let acc_store = store_read.account_store(account.num())?;
+
+    let mut input_assets = vec![];
+    let mut input_abfs = vec![];
+    let mut input_vbfs = vec![];
+    let mut input_ags = vec![];
+    let mut input_values = vec![];
+
+    for input in tx.input.iter() {
+        info!("input {:?}", input);
+
+        let unblinded = acc_store
+            .unblinded
+            .get(&input.previous_output)
+            .ok_or_else(|| Error::Generic("cannot find unblinded values".into()))?;
+        info!("unblinded value: {} asset:{}", unblinded.value, hex::encode(&unblinded.asset[..]));
+
+        input_values.push(unblinded.value);
+        input_assets.extend(unblinded.asset.to_vec());
+        input_abfs.extend(unblinded.abf.to_vec());
+        input_vbfs.extend(unblinded.vbf.to_vec());
+        let input_asset = asset_generator_from_bytes(&unblinded.asset, &unblinded.abf);
+        input_ags.extend(elements::encode::serialize(&input_asset));
+    }
+
+    let ct_exp = account.network.ct_exponent.expect("ct_exponent not set in network");
+    let ct_bits = account.network.ct_bits.expect("ct_bits not set in network");
+    info!("ct params ct_exp:{}, ct_bits:{}", ct_exp, ct_bits);
+
+    let mut output_blinded_values = vec![];
+    for output in tx.output.iter() {
+        if !output.is_fee() {
+            output_blinded_values.push(output.minimum_value());
+        }
+    }
+    info!("output_blinded_values {:?}", output_blinded_values);
+    let mut all_values = vec![];
+    all_values.extend(input_values);
+    all_values.extend(output_blinded_values);
+    let in_num = tx.input.len();
+    let out_num = tx.output.len();
+
+    let output_abfs: Vec<Vec<u8>> = (0..out_num - 1).map(|_| random32()).collect();
+    let mut output_vbfs: Vec<Vec<u8>> = (0..out_num - 2).map(|_| random32()).collect();
+
+    let mut all_abfs = vec![];
+    all_abfs.extend(input_abfs.to_vec());
+    all_abfs.extend(output_abfs.iter().cloned().flatten().collect::<Vec<u8>>());
+
+    let mut all_vbfs = vec![];
+    all_vbfs.extend(input_vbfs.to_vec());
+    all_vbfs.extend(output_vbfs.iter().cloned().flatten().collect::<Vec<u8>>());
+
+    let last_vbf = asset_final_vbf(all_values, in_num as u32, all_abfs, all_vbfs);
+    output_vbfs.push(last_vbf.to_vec());
+
+    for (i, mut output) in tx.output.iter_mut().enumerate() {
+        info!("output {:?}", output);
+        if !output.is_fee() {
+            match (output.value, output.asset, output.nonce) {
+                (Value::Explicit(value), Asset::Explicit(asset), Nonce::Confidential(_, _)) => {
+                    info!("value: {}", value);
+                    let nonce = elements::encode::serialize(&output.nonce);
+                    let blinding_pubkey = PublicKey::from_slice(&nonce).unwrap();
+                    let blinding_key = asset_blinding_key_to_ec_private_key(
+                        account.master_blinding.as_ref().unwrap(),
+                        &output.script_pubkey,
+                    );
+                    let blinding_public_key = ec_public_key_from_private_key(blinding_key);
+                    let mut output_abf = [0u8; 32];
+                    output_abf.copy_from_slice(&(&output_abfs[i])[..]);
+                    let mut output_vbf = [0u8; 32];
+                    output_vbf.copy_from_slice(&(&output_vbfs[i])[..]);
+                    let asset = asset.clone().into_inner();
+
+                    let output_generator =
+                        asset_generator_from_bytes(&asset.into_inner(), &output_abf);
+                    let output_value_commitment =
+                        asset_value_commitment(value, output_vbf, output_generator);
+                    let min_value = if output.script_pubkey.is_provably_unspendable() {
+                        0
+                    } else {
+                        1
+                    };
+
+                    let rangeproof = asset_rangeproof(
+                        value,
+                        blinding_pubkey.key,
+                        blinding_key,
+                        asset.into_inner(),
+                        output_abf,
+                        output_vbf,
+                        output_value_commitment,
+                        &output.script_pubkey,
+                        output_generator,
+                        min_value,
+                        ct_exp,
+                        ct_bits,
+                    );
+                    trace!("asset: {}", hex::encode(&asset));
+                    trace!("output_abf: {}", hex::encode(&output_abf));
+                    trace!(
+                        "output_generator: {}",
+                        hex::encode(&elements::encode::serialize(&output_generator))
+                    );
+                    trace!("input_assets: {}", hex::encode(&input_assets));
+                    trace!("input_abfs: {}", hex::encode(&input_abfs));
+                    trace!("input_ags: {}", hex::encode(&input_ags));
+                    trace!("in_num: {}", in_num);
+
+                    let surjectionproof = asset_surjectionproof(
+                        asset.into_inner(),
+                        output_abf,
+                        output_generator,
+                        output_abf,
+                        &input_assets,
+                        &input_abfs,
+                        &input_ags,
+                        in_num,
+                    );
+                    trace!("surjectionproof: {}", hex::encode(&surjectionproof));
+
+                    let bytes = blinding_public_key.serialize();
+                    let byte32: [u8; 32] = bytes[1..].as_ref().try_into().unwrap();
+                    output.nonce = elements::confidential::Nonce::Confidential(bytes[0], byte32);
+                    output.asset = output_generator;
+                    output.value = output_value_commitment;
+                    info!(
+                        "added size len: surjectionproof:{} rangeproof:{}",
+                        surjectionproof.len(),
+                        rangeproof.len()
+                    );
+                    output.witness.surjection_proof = surjectionproof;
+                    output.witness.rangeproof = rangeproof;
+                }
+                _ => panic!("create_tx created things not right"),
+            }
+        }
+    }
+    Ok(())
 }

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -158,8 +158,7 @@ impl Account {
                     });
                 }
             }
-            // @shesek FIXME per-account memos
-            let memo = store.get_memo(tx_id).map(|s| s.to_string());
+            let memo = store.get_memo(self.account_num, tx_id).cloned();
 
             let create_transaction = CreateTransaction {
                 addressees,
@@ -447,9 +446,8 @@ impl Account {
         }
 
         if let Some(memo) = request.create_transaction.as_ref().and_then(|c| c.memo.as_ref()) {
-            // @shesek TODO per-account memos
             let txid = BETxid::from_hex(&betx.txid, self.network.id())?;
-            store_write.insert_memo(txid, memo)?;
+            store_write.insert_memo(self.account_num, txid, memo)?;
         }
 
         Ok(betx)

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -72,6 +72,8 @@ impl Account {
         // cache internal/external chains
         let chains = [xpub.ckd_pub(&EC, 0.into())?, xpub.ckd_pub(&EC, 1.into())?];
 
+        store.write().unwrap().make_account_cache(account_num);
+
         Ok(Self {
             network,
             account_num,

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -512,11 +512,6 @@ impl From<u32> for AccountNum {
         AccountNum(num)
     }
 }
-impl From<usize> for AccountNum {
-    fn from(num: usize) -> Self {
-        AccountNum(num as u32)
-    }
-}
 impl Into<u32> for AccountNum {
     fn into(self) -> u32 {
         self.0

--- a/subprojects/gdk_rust/gdk_electrum/src/error.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
     AssetEmpty,
     InvalidHeaders,
     InvalidSubaccount(u32),
+    AccountGapsDisallowed,
     SendAll,
     PinError,
     AddrParse(String),
@@ -51,6 +52,9 @@ impl Display for Error {
             Error::EmptyAddressees => write!(f, "addressees cannot be empty"),
             Error::AssetEmpty => write!(f, "asset_tag cannot be empty in liquid"),
             Error::InvalidSubaccount(sub) => write!(f, "invalid subaccount {}", sub),
+            Error::AccountGapsDisallowed => {
+                write!(f, "cannot create a new subaccount while the last one is unused")
+            }
             Error::UnknownCall => write!(f, "unknown call"),
             Error::Bitcoin(ref btcerr) => write!(f, "bitcoin: {}", btcerr),
             Error::BitcoinHashes(ref btcerr) => write!(f, "bitcoin_hashes: {}", btcerr),

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use gdk_common::mnemonic::Mnemonic;
 use gdk_common::model::{
-    AddressPointer, Balances, CreateAccountOpt, CreateTransaction, GetTransactionsOpt, GetUnspentOpt, Settings,
-    TransactionMeta,
+    AddressPointer, Balances, CreateAccountOpt, CreateTransaction, GetTransactionsOpt,
+    GetUnspentOpt, Settings, TransactionMeta,
 };
 use gdk_common::network::Network;
 use gdk_common::wally::*;

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -10,7 +10,7 @@ use gdk_common::model::{
 use gdk_common::network::Network;
 use gdk_common::wally::*;
 
-use crate::account::{Account, AccountNum};
+use crate::account::{get_next_account_num, Account, AccountNum};
 use crate::error::*;
 use crate::store::*;
 
@@ -122,7 +122,10 @@ impl WalletCtx {
     }
 
     pub fn create_account(&mut self, opt: CreateAccountOpt) -> Result<&Account, Error> {
-        let next_num = self.accounts.keys().map(|n| n.as_u32()).max().map_or(0, |i| i + 1);
+        // Get the next available account number for the given script type.
+        // The script type is later derived from the account number.
+        let next_num = get_next_account_num(self.accounts.keys().collect(), opt.script_type);
+
         let account = self._ensure_account(next_num.into())?;
         account.set_name(opt.name)?;
         Ok(account)

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -1,34 +1,22 @@
-use bitcoin::blockdata::transaction::Transaction;
-use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::{self, All, Message, Secp256k1};
-use bitcoin::util::address::{Address, Payload};
-use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey};
-use bitcoin::{PublicKey, SigHashType};
-use elements;
-use gdk_common::model::{AddressAmount, Balances, GetTransactionsOpt, SPVVerifyResult};
-use hex;
-use log::{info, trace};
-use rand::Rng;
+use bitcoin::secp256k1::{All, Secp256k1};
+use bitcoin::util::bip32::{ExtendedPrivKey, ExtendedPubKey};
 use serde::{Deserialize, Serialize};
 
 use gdk_common::mnemonic::Mnemonic;
-use gdk_common::model::{AddressPointer, CreateTransaction, Settings, TransactionMeta};
-use gdk_common::network::{ElementsNetwork, Network, NetworkId};
-use gdk_common::scripts::{p2pkh_script, p2shwpkh_script, p2shwpkh_script_sig};
+use gdk_common::model::{
+    AddressPointer, Balances, CreateTransaction, GetTransactionsOpt, Settings, TransactionMeta,
+};
+use gdk_common::network::Network;
 use gdk_common::wally::*;
 
 use crate::account::{Account, AccountNum};
 use crate::error::*;
 use crate::store::*;
 
-use bitcoin::util::bip143::SigHashCache;
 use electrum_client::{Client, ConfigBuilder};
-use elements::confidential::{Asset, Nonce, Value};
-use gdk_common::be::{self, *};
-use std::cmp::Ordering;
+use gdk_common::be::*;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
-use std::convert::TryInto;
+use std::collections::HashMap;
 use std::str::FromStr;
 
 pub struct WalletCtx {
@@ -41,9 +29,6 @@ pub struct WalletCtx {
     pub master_blinding: Option<MasterBlindingKey>,
     pub accounts: HashMap<AccountNum, Account>,
     pub change_max_deriv: u32,
-
-    pub xprv: ExtendedPrivKey, // @shesek to be removed
-    pub xpub: ExtendedPubKey,  // @shesek to be removed
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -106,10 +91,6 @@ impl WalletCtx {
         master_blinding: Option<MasterBlindingKey>,
     ) -> Result<Self, Error> {
         Ok(WalletCtx {
-            // @shesek to be removed
-            xprv: master_xprv.clone(),
-            xpub: master_xpub.clone(),
-
             mnemonic,
             store,
             network, // TODO: from db
@@ -126,8 +107,8 @@ impl WalletCtx {
         &self.mnemonic
     }
 
-    pub fn get_account(&self, account_num: AccountNum) -> Option<&Account> {
-        self.accounts.get(&account_num)
+    pub fn get_account(&self, account_num: AccountNum) -> Result<&Account, Error> {
+        self.accounts.get(&account_num).ok_or_else(|| Error::InvalidSubaccount(account_num.into()))
     }
 
     pub fn iter_accounts(&self) -> impl Iterator<Item = &Account> {
@@ -147,10 +128,6 @@ impl WalletCtx {
         })
     }
 
-    fn derive_address(&self, is_change: bool, index: u32) -> Result<BEAddress, Error> {
-        self.get_account(0usize.into()).unwrap().derive_address(is_change, index)
-    }
-
     pub fn get_settings(&self) -> Result<Settings, Error> {
         Ok(self.store.read()?.get_settings().unwrap_or_default())
     }
@@ -165,799 +142,31 @@ impl WalletCtx {
     }
 
     pub fn list_tx(&self, opt: &GetTransactionsOpt) -> Result<Vec<TransactionMeta>, Error> {
-        let store_read = self.store.read()?;
-
-        let mut txs = vec![];
-        let mut my_txids: Vec<(&BETxid, &Option<u32>)> = store_read.cache.heights.iter().collect();
-        my_txids.sort_by(|a, b| {
-            let height_cmp = b.1.unwrap_or(std::u32::MAX).cmp(&a.1.unwrap_or(std::u32::MAX));
-            match height_cmp {
-                Ordering::Equal => b.0.cmp(a.0),
-                h @ _ => h,
-            }
-        });
-
-        for (tx_id, height) in my_txids.iter().skip(opt.first).take(opt.count) {
-            trace!("tx_id {}", tx_id);
-
-            let tx = store_read
-                .cache
-                .all_txs
-                .get(*tx_id)
-                .ok_or_else(fn_err(&format!("list_tx no tx {}", tx_id)))?;
-            let header = height.map(|h| store_read.cache.headers.get(&h)).flatten();
-            trace!("tx_id {} header {:?}", tx_id, header);
-            let mut addressees = vec![];
-            for i in 0..tx.output_len() as u32 {
-                let script = tx.output_script(i);
-                if !script.is_empty() && !store_read.cache.paths.contains_key(&script) {
-                    let address = tx.output_address(i, self.network.id());
-                    trace!("tx_id {}:{} not my script, address {:?}", tx_id, i, address);
-                    addressees.push(AddressAmount {
-                        address: address.unwrap_or_else(|| "".to_string()),
-                        satoshi: 0, // apparently not needed in list_tx addressees
-                        asset_tag: None,
-                    });
-                }
-            }
-            let memo = store_read.get_memo(tx_id).map(|s| s.to_string());
-
-            let create_transaction = CreateTransaction {
-                addressees,
-                memo,
-                ..Default::default()
-            };
-
-            let fee = tx.fee(
-                &store_read.cache.all_txs,
-                &store_read.cache.unblinded,
-                &self.network.policy_asset().ok(),
-            )?;
-            trace!("tx_id {} fee {}", tx_id, fee);
-
-            let satoshi = tx.my_balance_changes(
-                &store_read.cache.all_txs,
-                &store_read.cache.paths,
-                &store_read.cache.unblinded,
-            );
-            trace!("tx_id {} balances {:?}", tx_id, satoshi);
-
-            // We define an incoming txs if there are more assets received by the wallet than spent
-            // when they are equal it's an outgoing tx because the special asset liquid BTC
-            // is negative due to the fee being paid
-            // TODO how do we label issuance tx?
-            let negatives = satoshi.iter().filter(|(_, v)| **v < 0).count();
-            let positives = satoshi.iter().filter(|(_, v)| **v > 0).count();
-            let (type_, user_signed) = match (
-                positives > negatives,
-                tx.is_redeposit(&store_read.cache.paths, &store_read.cache.all_txs),
-            ) {
-                (_, true) => ("redeposit", true),
-                (true, false) => ("incoming", false),
-                (false, false) => ("outgoing", true),
-            };
-
-            let spv_verified = if self.network.spv_enabled.unwrap_or(false) {
-                store_read.spv_verification_status(tx_id)
-            } else {
-                SPVVerifyResult::Disabled
-            };
-
-            trace!(
-                "tx_id {} type {} user_signed {} spv_verified {:?}",
-                tx_id,
-                type_,
-                user_signed,
-                spv_verified
-            );
-
-            let tx_meta = TransactionMeta::new(
-                tx.clone(),
-                **height,
-                header.map(|h| h.time()),
-                satoshi,
-                fee,
-                self.network.id().get_bitcoin_network().unwrap_or(bitcoin::Network::Bitcoin),
-                type_.to_string(),
-                create_transaction,
-                user_signed,
-                spv_verified,
-            );
-
-            txs.push(tx_meta);
-        }
-        info!("list_tx {:?}", txs.iter().map(|e| &e.txid).collect::<Vec<&String>>());
-
-        Ok(txs)
+        self.get_account(opt.subaccount.into())?.list_tx(opt)
     }
 
     pub fn utxos(&self) -> Result<Utxos, Error> {
-        info!("start utxos");
-
-        let store_read = self.store.read()?;
-        let mut utxos = vec![];
-        let spent = store_read.spent()?;
-        for (tx_id, height) in store_read.cache.heights.iter() {
-            let tx = store_read
-                .cache
-                .all_txs
-                .get(tx_id)
-                .ok_or_else(fn_err(&format!("utxos no tx {}", tx_id)))?;
-            let tx_utxos: Vec<(BEOutPoint, UTXOInfo)> = match tx {
-                BETransaction::Bitcoin(tx) => tx
-                    .output
-                    .clone()
-                    .into_iter()
-                    .enumerate()
-                    .filter(|(_, output)| output.value > DUST_VALUE)
-                    .map(|(vout, output)| (BEOutPoint::new_bitcoin(tx.txid(), vout as u32), output))
-                    .filter_map(|(vout, output)| {
-                        store_read
-                            .cache
-                            .paths
-                            .get(&(&output.script_pubkey).into())
-                            .map(|path| (vout, output, path))
-                    })
-                    .filter(|(outpoint, _, _)| !spent.contains(&outpoint))
-                    .map(|(outpoint, output, path)| {
-                        (
-                            outpoint,
-                            UTXOInfo::new(
-                                "btc".to_string(),
-                                output.value,
-                                output.script_pubkey.into(),
-                                height.clone(),
-                                path.clone(),
-                            ),
-                        )
-                    })
-                    .collect(),
-                BETransaction::Elements(tx) => {
-                    let policy_asset = self.network.policy_asset_id()?;
-                    tx.output
-                        .clone()
-                        .into_iter()
-                        .enumerate()
-                        .map(|(vout, output)| {
-                            (BEOutPoint::new_elements(tx.txid(), vout as u32), output)
-                        })
-                        .filter_map(|(vout, output)| {
-                            store_read
-                                .cache
-                                .paths
-                                .get(&(&output.script_pubkey).into())
-                                .map(|path| (vout, output, path))
-                        })
-                        .filter(|(outpoint, _, _)| !spent.contains(&outpoint))
-                        .filter_map(|(outpoint, output, path)| {
-                            if let BEOutPoint::Elements(el_outpoint) = outpoint {
-                                if let Some(unblinded) =
-                                    store_read.cache.unblinded.get(&el_outpoint)
-                                {
-                                    if unblinded.value < DUST_VALUE
-                                        && unblinded.asset == policy_asset
-                                    {
-                                        return None;
-                                    }
-                                    return Some((
-                                        outpoint,
-                                        UTXOInfo::new(
-                                            unblinded.asset_hex(),
-                                            unblinded.value,
-                                            output.script_pubkey.into(),
-                                            height.clone(),
-                                            path.clone(),
-                                        ),
-                                    ));
-                                }
-                            }
-                            None
-                        })
-                        .collect()
-                }
-            };
-            utxos.extend(tx_utxos);
-        }
-        utxos.sort_by(|a, b| (b.1).value.cmp(&(a.1).value));
-
-        Ok(utxos)
+        // @shesek TODO support multiple accounts
+        self.get_account(0usize.into())?.utxos()
     }
 
     pub fn balance(&self) -> Result<Balances, Error> {
-        info!("start balance");
-        let mut result = HashMap::new();
-        match self.network.id() {
-            NetworkId::Bitcoin(_) => result.entry("btc".to_string()).or_insert(0),
-            NetworkId::Elements(_) => {
-                result.entry(self.network.policy_asset.as_ref().unwrap().clone()).or_insert(0)
-            }
-        };
-        for (_, info) in self.utxos()?.iter() {
-            *result.entry(info.asset.clone()).or_default() += info.value as i64;
-        }
-        Ok(result)
+        // @shesek TODO support multiple accounts
+        self.get_account(0usize.into())?.balance()
     }
 
-    #[allow(clippy::cognitive_complexity)]
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {
-        info!("create_tx {:?}", request);
-
-        // TODO put checks into CreateTransaction::validate, add check asset_tag are valid asset hex
-        // eagerly check for address validity
-        for address in request.addressees.iter().map(|a| &a.address) {
-            match self.network.id() {
-                NetworkId::Bitcoin(network) => {
-                    if let Ok(address) = bitcoin::Address::from_str(address) {
-                        info!("address.network:{} network:{}", address.network, network);
-                        if address.network == network
-                            || (address.network == bitcoin::Network::Testnet
-                                && network == bitcoin::Network::Regtest)
-                        {
-                            continue;
-                        }
-                        if let Payload::WitnessProgram {
-                            version: v,
-                            program: _p,
-                        } = &address.payload
-                        {
-                            // Do not support segwit greater than v0
-                            if v.to_u8() > 0 {
-                                return Err(Error::InvalidAddress);
-                            }
-                        }
-                    }
-                    return Err(Error::InvalidAddress);
-                }
-                NetworkId::Elements(network) => {
-                    if let Ok(address) = elements::Address::from_str(address) {
-                        info!(
-                            "address.params:{:?} address_params(network):{:?}",
-                            address.params,
-                            address_params(network)
-                        );
-                        if address.params == address_params(network) {
-                            continue;
-                        }
-                    }
-                    return Err(Error::InvalidAddress);
-                }
-            }
-        }
-
-        if request.addressees.is_empty() {
-            return Err(Error::EmptyAddressees);
-        }
-
-        let subaccount = request.subaccount.unwrap_or(0);
-        if subaccount != 0 {
-            return Err(Error::InvalidSubaccount(subaccount));
-        }
-
-        if !request.previous_transaction.is_empty() {
-            return Err(Error::Generic("bump not supported".into()));
-        }
-
-        let send_all = request.send_all.unwrap_or(false);
-        request.send_all = Some(send_all); // accept default false, but always return the value
-        if !send_all && request.addressees.iter().any(|a| a.satoshi == 0) {
-            return Err(Error::InvalidAmount);
-        }
-
-        if !send_all {
-            for address_amount in request.addressees.iter() {
-                if address_amount.satoshi <= be::DUST_VALUE {
-                    match self.network.id() {
-                        NetworkId::Bitcoin(_) => return Err(Error::InvalidAmount),
-                        NetworkId::Elements(_) => {
-                            if address_amount.asset_tag == self.network.policy_asset {
-                                // we apply dust rules for liquid bitcoin as elements do
-                                return Err(Error::InvalidAmount);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if let NetworkId::Elements(_) = self.network.id() {
-            if request.addressees.iter().any(|a| a.asset_tag.is_none()) {
-                return Err(Error::AssetEmpty);
-            }
-        }
-
-        // convert from satoshi/kbyte to satoshi/byte
-        let default_value = match self.network.id() {
-            NetworkId::Bitcoin(_) => 1000,
-            NetworkId::Elements(_) => 100,
-        };
-        let fee_rate = (request.fee_rate.unwrap_or(default_value) as f64) / 1000.0;
-        info!("target fee_rate {:?} satoshi/byte", fee_rate);
-
-        let utxos = match &request.utxos {
-            None => self.utxos()?,
-            Some(utxos) => utxos.try_into()?,
-        };
-        info!("utxos len:{} utxos:{:?}", utxos.len(), utxos);
-
-        if send_all {
-            // send_all works by creating a dummy tx with all utxos, estimate the fee and set the
-            // sending amount to `total_amount_utxos - estimated_fee`
-            info!("send_all calculating total_amount");
-            if request.addressees.len() != 1 {
-                return Err(Error::SendAll);
-            }
-            let asset = request.addressees[0].asset_tag.as_deref().unwrap_or("btc");
-            let all_utxos: Vec<&(BEOutPoint, UTXOInfo)> =
-                utxos.iter().filter(|(_, i)| i.asset == asset).collect();
-            let total_amount_utxos: u64 = all_utxos.iter().map(|(_, i)| i.value).sum();
-
-            let to_send = if asset == "btc" || Some(asset.to_string()) == self.network.policy_asset
-            {
-                let mut dummy_tx = BETransaction::new(self.network.id());
-                for utxo in all_utxos.iter() {
-                    dummy_tx.add_input(utxo.0.clone());
-                }
-                let out = &request.addressees[0]; // safe because we checked we have exactly one recipient
-                dummy_tx
-                    .add_output(&out.address, out.satoshi, out.asset_tag.clone())
-                    .map_err(|_| Error::InvalidAddress)?;
-                let estimated_fee = dummy_tx.estimated_fee(fee_rate, 0) + 3; // estimating 3 satoshi more as estimating less would later result in InsufficientFunds
-                total_amount_utxos
-                    .checked_sub(estimated_fee)
-                    .ok_or_else(|| Error::InsufficientFunds)?
-            } else {
-                total_amount_utxos
-            };
-
-            info!("send_all asset: {} to_send:{}", asset, to_send);
-
-            request.addressees[0].satoshi = to_send;
-        }
-
-        let mut tx = BETransaction::new(self.network.id());
-        // transaction is created in 3 steps:
-        // 1) adding requested outputs to tx outputs
-        // 2) adding enough utxso to inputs such that tx outputs and estimated fees are covered
-        // 3) adding change(s)
-
-        // STEP 1) add the outputs requested for this transactions
-        for out in request.addressees.iter() {
-            tx.add_output(&out.address, out.satoshi, out.asset_tag.clone())
-                .map_err(|_| Error::InvalidAddress)?;
-        }
-
-        // STEP 2) add utxos until tx outputs are covered (including fees) or fail
-        let store_read = self.store.read()?;
-        let mut used_utxo: HashSet<BEOutPoint> = HashSet::new();
-        loop {
-            let mut needs = tx.needs(
-                fee_rate,
-                send_all,
-                self.network.policy_asset.clone(),
-                &store_read.cache.all_txs,
-                &store_read.cache.unblinded,
-            ); // Vec<(asset_string, satoshi)  "policy asset" is last, in bitcoin asset_string="btc" and max 1 element
-            info!("needs: {:?}", needs);
-            if needs.is_empty() {
-                // SUCCESS tx doesn't need other inputs
-                break;
-            }
-            let current_need = needs.pop().unwrap(); // safe to unwrap just checked it's not empty
-
-            // taking only utxos of current asset considered, filters also utxos used in this loop
-            let mut asset_utxos: Vec<&(BEOutPoint, UTXOInfo)> = utxos
-                .iter()
-                .filter(|(o, i)| i.asset == current_need.asset && !used_utxo.contains(o))
-                .collect();
-
-            // sort by biggest utxo, random maybe another option, but it should be deterministically random (purely random breaks send_all algorithm)
-            asset_utxos.sort_by(|a, b| (a.1).value.cmp(&(b.1).value));
-            let utxo = asset_utxos.pop().ok_or(Error::InsufficientFunds)?;
-
-            match self.network.id() {
-                NetworkId::Bitcoin(_) => {
-                    // UTXO with same script must be spent together
-                    for other_utxo in utxos.iter() {
-                        if (other_utxo.1).script == (utxo.1).script {
-                            used_utxo.insert(other_utxo.0.clone());
-                            tx.add_input(other_utxo.0.clone());
-                        }
-                    }
-                }
-                NetworkId::Elements(_) => {
-                    // Don't spend same script together in liquid. This would allow an attacker
-                    // to cheaply send assets without value to the target, which will have to
-                    // waste fees for the extra tx inputs and (eventually) outputs.
-                    // While blinded address are required and not public knowledge,
-                    // they are still available to whom transacted with us in the past
-                    used_utxo.insert(utxo.0.clone());
-                    tx.add_input(utxo.0.clone());
-                }
-            }
-        }
-
-        // STEP 3) adding change(s)
-        let estimated_fee = tx.estimated_fee(
-            fee_rate,
-            tx.estimated_changes(send_all, &store_read.cache.all_txs, &store_read.cache.unblinded),
-        );
-        let changes = tx.changes(
-            estimated_fee,
-            self.network.policy_asset.clone(),
-            &store_read.cache.all_txs,
-            &store_read.cache.unblinded,
-        ); // Vec<Change> asset, value
-        for (i, change) in changes.iter().enumerate() {
-            let change_index = store_read.cache.indexes.internal + i as u32 + 1;
-            let change_address = self.derive_address(true, change_index)?.to_string();
-            info!(
-                "adding change to {} of {} asset {:?}",
-                &change_address, change.satoshi, change.asset
-            );
-            tx.add_output(&change_address, change.satoshi, Some(change.asset.clone()))?;
-        }
-
-        // randomize inputs and outputs, BIP69 has been rejected because lacks wallets adoption
-        tx.scramble();
-
-        let policy_asset = self.network.policy_asset().ok();
-        let fee_val =
-            tx.fee(&store_read.cache.all_txs, &store_read.cache.unblinded, &policy_asset)?; // recompute exact fee_val from built tx
-        tx.add_fee_if_elements(fee_val, &policy_asset)?;
-
-        info!("created tx fee {:?}", fee_val);
-
-        let mut satoshi = tx.my_balance_changes(
-            &store_read.cache.all_txs,
-            &store_read.cache.paths,
-            &store_read.cache.unblinded,
-        );
-
-        for (_, v) in satoshi.iter_mut() {
-            *v = v.abs();
-        }
-
-        let mut created_tx = TransactionMeta::new(
-            tx,
-            None,
-            None,
-            satoshi,
-            fee_val,
-            self.network.id().get_bitcoin_network().unwrap_or(bitcoin::Network::Bitcoin),
-            "outgoing".to_string(),
-            request.clone(),
-            true,
-            SPVVerifyResult::InProgress,
-        );
-        created_tx.changes_used = Some(changes.len() as u32);
-        info!("returning: {:?}", created_tx);
-
-        Ok(created_tx)
-    }
-
-    // TODO when we can serialize psbt
-    //pub fn sign(&self, psbt: PartiallySignedTransaction) -> Result<PartiallySignedTransaction, Error> { Err(Error::Generic("NotImplemented".to_string())) }
-
-    fn internal_sign_bitcoin(
-        &self,
-        tx: &Transaction,
-        input_index: usize,
-        path: &DerivationPath,
-        value: u64,
-    ) -> (bitcoin::Script, Vec<Vec<u8>>) {
-        let xprv = self.xprv.derive_priv(&self.secp, &path).unwrap();
-        let private_key = &xprv.private_key;
-        let public_key = &PublicKey::from_private_key(&self.secp, private_key);
-        let witness_script = p2pkh_script(public_key);
-
-        let hash = SigHashCache::new(tx).signature_hash(
-            input_index,
-            &witness_script,
-            value,
-            SigHashType::All,
-        );
-
-        let message = Message::from_slice(&hash.into_inner()[..]).unwrap();
-        let signature = self.secp.sign(&message, &private_key.key);
-
-        let mut signature = signature.serialize_der().to_vec();
-        signature.push(SigHashType::All as u8);
-
-        let script_sig = p2shwpkh_script_sig(public_key);
-        let witness = vec![signature, public_key.to_bytes()];
-        info!(
-            "added size len: script_sig:{} witness:{}",
-            script_sig.len(),
-            witness.iter().map(|v| v.len()).sum::<usize>()
-        );
-
-        (script_sig, witness)
-    }
-
-    pub fn internal_sign_elements(
-        &self,
-        tx: &elements::Transaction,
-        input_index: usize,
-        derivation_path: &DerivationPath,
-        value: Value,
-    ) -> (elements::Script, Vec<Vec<u8>>) {
-        let xprv = self.xprv.derive_priv(&self.secp, &derivation_path).unwrap();
-        let private_key = &xprv.private_key;
-        let public_key = &PublicKey::from_private_key(&self.secp, private_key);
-
-        let script_code = p2pkh_script(public_key).into_elements();
-        let sighash = tx_get_elements_signature_hash(
-            &tx,
-            input_index,
-            &script_code,
-            &value,
-            SigHashType::All.as_u32(),
-            true, // segwit
-        );
-        let message = secp256k1::Message::from_slice(&sighash[..]).unwrap();
-        let signature = self.secp.sign(&message, &private_key.key);
-        let mut signature = signature.serialize_der().to_vec();
-        signature.push(SigHashType::All as u8);
-
-        let script_sig = p2shwpkh_script_sig(public_key).into_elements();
-        let witness = vec![signature, public_key.to_bytes()];
-        info!(
-            "added size len: script_sig:{} witness:{}",
-            script_sig.len(),
-            witness.iter().map(|v| v.len()).sum::<usize>()
-        );
-        (script_sig, witness)
+        self.get_account(0usize.into())?.create_tx(request)
     }
 
     pub fn sign(&self, request: &TransactionMeta) -> Result<TransactionMeta, Error> {
-        info!("sign");
-        let be_tx = BETransaction::deserialize(&hex::decode(&request.hex)?, self.network.id())?;
-        let store_read = self.store.read()?;
-        let mut betx: TransactionMeta = match be_tx {
-            BETransaction::Bitcoin(tx) => {
-                let mut out_tx = tx.clone();
-
-                for i in 0..tx.input.len() {
-                    let prev_output = tx.input[i].previous_output;
-                    info!("input#{} prev_output:{:?}", i, prev_output);
-                    let prev_tx = store_read.get_bitcoin_tx(&prev_output.txid)?;
-                    let out = prev_tx.output[prev_output.vout as usize].clone();
-                    let derivation_path: DerivationPath = store_read
-                        .cache
-                        .paths
-                        .get(&out.script_pubkey.into())
-                        .ok_or_else(|| Error::Generic("can't find derivation path".into()))?
-                        .clone();
-                    info!(
-                        "input#{} prev_output:{:?} derivation_path:{:?}",
-                        i, prev_output, derivation_path
-                    );
-
-                    let (script_sig, witness) =
-                        self.internal_sign_bitcoin(&tx, i, &derivation_path, out.value);
-
-                    out_tx.input[i].script_sig = script_sig;
-                    out_tx.input[i].witness = witness;
-                }
-                let tx = BETransaction::Bitcoin(out_tx);
-                info!(
-                    "transaction final size is {} bytes and {} vbytes",
-                    tx.serialize().len(),
-                    tx.get_weight() / 4
-                );
-                info!("FINALTX inputs:{} outputs:{}", tx.input_len(), tx.output_len());
-                tx.into()
-            }
-            BETransaction::Elements(mut tx) => {
-                self.blind_tx(&mut tx)?;
-
-                for i in 0..tx.input.len() {
-                    let prev_output = tx.input[i].previous_output;
-                    info!("input#{} prev_output:{:?}", i, prev_output);
-                    let prev_tx = store_read.get_liquid_tx(&prev_output.txid)?;
-                    let out = prev_tx.output[prev_output.vout as usize].clone();
-                    let derivation_path: DerivationPath = store_read
-                        .cache
-                        .paths
-                        .get(&out.script_pubkey.into())
-                        .ok_or_else(|| Error::Generic("can't find derivation path".into()))?
-                        .clone();
-
-                    let (script_sig, witness) =
-                        self.internal_sign_elements(&tx, i, &derivation_path, out.value);
-
-                    tx.input[i].script_sig = script_sig;
-                    tx.input[i].witness.script_witness = witness;
-                }
-
-                let fee: u64 =
-                    tx.output.iter().filter(|o| o.is_fee()).map(|o| o.minimum_value()).sum();
-                let tx = BETransaction::Elements(tx);
-                info!(
-                    "transaction final size is {} bytes and {} vbytes and fee is {}",
-                    tx.serialize().len(),
-                    tx.get_weight() / 4,
-                    fee
-                );
-                info!("FINALTX inputs:{} outputs:{}", tx.input_len(), tx.output_len());
-                tx.into()
-            }
-        };
-
-        betx.fee = request.fee;
-        betx.create_transaction = request.create_transaction.clone();
-
-        drop(store_read);
-        let mut store_write = self.store.write()?;
-
-        let changes_used = request.changes_used.unwrap_or(0);
-        if changes_used > 0 {
-            info!("tx used {} changes", changes_used);
-            // The next sync would update the internal index but we increment the internal index also
-            // here after sign so that if we immediately create another tx we are not reusing addresses
-            // This implies signing multiple times without broadcasting leads to gaps in the internal chain
-            store_write.cache.indexes.internal += changes_used;
-        }
-
-        if let Some(memo) = request.create_transaction.as_ref().and_then(|c| c.memo.as_ref()) {
-            let txid = BETxid::from_hex(&betx.txid, self.network.id())?;
-            store_write.insert_memo(txid, memo)?;
-        }
-
-        Ok(betx)
-    }
-
-    fn blind_tx(&self, tx: &mut elements::Transaction) -> Result<(), Error> {
-        info!("blind_tx {}", tx.txid());
-        let mut input_assets = vec![];
-        let mut input_abfs = vec![];
-        let mut input_vbfs = vec![];
-        let mut input_ags = vec![];
-        let mut input_values = vec![];
-        let store_read = self.store.read()?;
-        for input in tx.input.iter() {
-            info!("input {:?}", input);
-
-            let unblinded = store_read
-                .cache
-                .unblinded
-                .get(&input.previous_output)
-                .ok_or_else(|| Error::Generic("cannot find unblinded values".into()))?;
-            info!(
-                "unblinded value: {} asset:{}",
-                unblinded.value,
-                hex::encode(&unblinded.asset[..])
-            );
-
-            input_values.push(unblinded.value);
-            input_assets.extend(unblinded.asset.to_vec());
-            input_abfs.extend(unblinded.abf.to_vec());
-            input_vbfs.extend(unblinded.vbf.to_vec());
-            let input_asset = asset_generator_from_bytes(&unblinded.asset, &unblinded.abf);
-            input_ags.extend(elements::encode::serialize(&input_asset));
-        }
-
-        let ct_exp = self.network.ct_exponent.expect("ct_exponent not set in network");
-        let ct_bits = self.network.ct_bits.expect("ct_bits not set in network");
-        info!("ct params ct_exp:{}, ct_bits:{}", ct_exp, ct_bits);
-
-        let mut output_blinded_values = vec![];
-        for output in tx.output.iter() {
-            if !output.is_fee() {
-                output_blinded_values.push(output.minimum_value());
-            }
-        }
-        info!("output_blinded_values {:?}", output_blinded_values);
-        let mut all_values = vec![];
-        all_values.extend(input_values);
-        all_values.extend(output_blinded_values);
-        let in_num = tx.input.len();
-        let out_num = tx.output.len();
-
-        let output_abfs: Vec<Vec<u8>> = (0..out_num - 1).map(|_| random32()).collect();
-        let mut output_vbfs: Vec<Vec<u8>> = (0..out_num - 2).map(|_| random32()).collect();
-
-        let mut all_abfs = vec![];
-        all_abfs.extend(input_abfs.to_vec());
-        all_abfs.extend(output_abfs.iter().cloned().flatten().collect::<Vec<u8>>());
-
-        let mut all_vbfs = vec![];
-        all_vbfs.extend(input_vbfs.to_vec());
-        all_vbfs.extend(output_vbfs.iter().cloned().flatten().collect::<Vec<u8>>());
-
-        let last_vbf = asset_final_vbf(all_values, in_num as u32, all_abfs, all_vbfs);
-        output_vbfs.push(last_vbf.to_vec());
-
-        for (i, mut output) in tx.output.iter_mut().enumerate() {
-            info!("output {:?}", output);
-            if !output.is_fee() {
-                match (output.value, output.asset, output.nonce) {
-                    (Value::Explicit(value), Asset::Explicit(asset), Nonce::Confidential(_, _)) => {
-                        info!("value: {}", value);
-                        let nonce = elements::encode::serialize(&output.nonce);
-                        let blinding_pubkey = PublicKey::from_slice(&nonce).unwrap();
-                        let blinding_key = asset_blinding_key_to_ec_private_key(
-                            self.master_blinding.as_ref().unwrap(),
-                            &output.script_pubkey,
-                        );
-                        let blinding_public_key = ec_public_key_from_private_key(blinding_key);
-                        let mut output_abf = [0u8; 32];
-                        output_abf.copy_from_slice(&(&output_abfs[i])[..]);
-                        let mut output_vbf = [0u8; 32];
-                        output_vbf.copy_from_slice(&(&output_vbfs[i])[..]);
-                        let asset = asset.clone().into_inner();
-
-                        let output_generator =
-                            asset_generator_from_bytes(&asset.into_inner(), &output_abf);
-                        let output_value_commitment =
-                            asset_value_commitment(value, output_vbf, output_generator);
-                        let min_value = if output.script_pubkey.is_provably_unspendable() {
-                            0
-                        } else {
-                            1
-                        };
-
-                        let rangeproof = asset_rangeproof(
-                            value,
-                            blinding_pubkey.key,
-                            blinding_key,
-                            asset.into_inner(),
-                            output_abf,
-                            output_vbf,
-                            output_value_commitment,
-                            &output.script_pubkey,
-                            output_generator,
-                            min_value,
-                            ct_exp,
-                            ct_bits,
-                        );
-                        trace!("asset: {}", hex::encode(&asset));
-                        trace!("output_abf: {}", hex::encode(&output_abf));
-                        trace!(
-                            "output_generator: {}",
-                            hex::encode(&elements::encode::serialize(&output_generator))
-                        );
-                        trace!("input_assets: {}", hex::encode(&input_assets));
-                        trace!("input_abfs: {}", hex::encode(&input_abfs));
-                        trace!("input_ags: {}", hex::encode(&input_ags));
-                        trace!("in_num: {}", in_num);
-
-                        let surjectionproof = asset_surjectionproof(
-                            asset.into_inner(),
-                            output_abf,
-                            output_generator,
-                            output_abf,
-                            &input_assets,
-                            &input_abfs,
-                            &input_ags,
-                            in_num,
-                        );
-                        trace!("surjectionproof: {}", hex::encode(&surjectionproof));
-
-                        let bytes = blinding_public_key.serialize();
-                        let byte32: [u8; 32] = bytes[1..].as_ref().try_into().unwrap();
-                        output.nonce =
-                            elements::confidential::Nonce::Confidential(bytes[0], byte32);
-                        output.asset = output_generator;
-                        output.value = output_value_commitment;
-                        info!(
-                            "added size len: surjectionproof:{} rangeproof:{}",
-                            surjectionproof.len(),
-                            rangeproof.len()
-                        );
-                        output.witness.surjection_proof = surjectionproof;
-                        output.witness.rangeproof = rangeproof;
-                    }
-                    _ => panic!("create_tx created things not right"),
-                }
-            }
-        }
-        Ok(())
+        // @shesek TODO support multiple accounts
+        self.get_account(0usize.into())?.sign(request)
     }
 
     pub fn get_address(&self) -> Result<AddressPointer, Error> {
         // @shesek TODO multi-account support
-        self.get_account(0usize.into()).unwrap().get_next_address()
+        self.get_account(0usize.into())?.get_next_address()
     }
 
     pub fn get_asset_icons(&self) -> Result<Option<serde_json::Value>, Error> {
@@ -966,17 +175,6 @@ impl WalletCtx {
     pub fn get_asset_registry(&self) -> Result<Option<serde_json::Value>, Error> {
         self.store.read()?.read_asset_registry()
     }
-}
-
-fn address_params(net: ElementsNetwork) -> &'static elements::AddressParams {
-    match net {
-        ElementsNetwork::Liquid => &elements::AddressParams::LIQUID,
-        ElementsNetwork::ElementsRegtest => &elements::AddressParams::ELEMENTS,
-    }
-}
-
-fn random32() -> Vec<u8> {
-    rand::thread_rng().gen::<[u8; 32]>().to_vec()
 }
 
 #[cfg(test)]

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -188,12 +188,12 @@ impl WalletCtx {
     }
 
     pub fn utxos(&self, opt: &GetUnspentOpt) -> Result<Utxos, Error> {
-        // TODO does not support the `num_confs` and `all_coins` options
-        self.get_account(opt.subaccount)?.utxos()
+        // TODO does not support the `all_coins` option
+        self.get_account(opt.subaccount)?.utxos(opt.num_confs.unwrap_or(0))
     }
 
-    pub fn balance(&self, account_num: u32) -> Result<Balances, Error> {
-        self.get_account(account_num)?.balance()
+    pub fn balance(&self, account_num: u32, num_confs: u32) -> Result<Balances, Error> {
+        self.get_account(account_num)?.balance(num_confs)
     }
 
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use gdk_common::mnemonic::Mnemonic;
 use gdk_common::model::{
     AddressPointer, Balances, CreateAccountOpt, CreateTransaction, GetTransactionsOpt,
-    GetUnspentOpt, Settings, TransactionMeta,
+    GetUnspentOpt, Settings, TransactionMeta, UpdateAccountOpt,
 };
 use gdk_common::network::Network;
 use gdk_common::wally::*;
@@ -147,6 +147,10 @@ impl WalletCtx {
 
     pub fn rename_account(&mut self, account_num: u32, new_name: &str) -> Result<(), Error> {
         self.get_account(account_num)?.set_name(new_name)
+    }
+
+    pub fn update_account(&mut self, opt: UpdateAccountOpt) -> Result<(), Error> {
+        self.get_account(opt.subaccount)?.set_settings(opt)
     }
 
     pub fn recover_accounts(&mut self, electrum_url: &ElectrumUrl) -> Result<(), Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -121,6 +121,12 @@ impl WalletCtx {
         self.accounts.values()
     }
 
+    pub fn iter_accounts_sorted(&self) -> impl Iterator<Item = &Account> {
+        let mut accounts = self.accounts.iter().collect::<Vec<_>>();
+        accounts.sort_unstable_by(|(a_num, _), (b_num, _)| a_num.cmp(b_num));
+        accounts.into_iter().map(|(_, account)| account)
+    }
+
     pub fn create_account(&mut self, opt: CreateAccountOpt) -> Result<&Account, Error> {
         // Get the next available account number for the given script type.
         // The script type is later derived from the account number.

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -197,15 +197,15 @@ impl WalletCtx {
     }
 
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {
-        // @shesek XXX how to handle missing subaccount?
-        let account_num = request.subaccount.unwrap_or(0);
-        self.get_account(account_num)?.create_tx(request)
+        self.get_account(request.subaccount)?.create_tx(request)
     }
 
     pub fn sign(&self, request: &TransactionMeta) -> Result<TransactionMeta, Error> {
-        // @shesek XXX how to handle missing subaccount (or create_transaction)?
-        let account_num =
-            request.create_transaction.as_ref().and_then(|c| c.subaccount).unwrap_or(0);
+        let account_num = request
+            .create_transaction
+            .as_ref()
+            .ok_or_else(|| Error::Generic("Cannot sign without tx data".into()))?
+            .subaccount;
         self.get_account(account_num)?.sign(request)
     }
 

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -10,7 +10,7 @@ use gdk_common::model::{
 use gdk_common::network::Network;
 use gdk_common::wally::*;
 
-use crate::account::{get_next_account_num, Account, AccountNum};
+use crate::account::{discover_accounts, get_next_account_num, Account, AccountNum};
 use crate::error::*;
 use crate::store::*;
 
@@ -135,6 +135,19 @@ impl WalletCtx {
         let account = self._ensure_account(next_num.into())?;
         account.set_name(opt.name)?;
         Ok(account)
+    }
+
+    pub fn recover_accounts(&mut self, electrum_url: &ElectrumUrl) -> Result<(), Error> {
+        let account_nums = discover_accounts(
+            &self.master_xprv,
+            self.network.id(),
+            electrum_url,
+            self.master_blinding.as_ref(),
+        )?;
+        for account_num in account_nums {
+            self._ensure_account(account_num)?;
+        }
+        Ok(())
     }
 
     fn _ensure_account(&mut self, account_num: AccountNum) -> Result<&mut Account, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -140,8 +140,12 @@ impl WalletCtx {
         }
 
         let account = self._ensure_account(next_account)?;
-        account.set_name(opt.name)?;
+        account.set_name(&opt.name)?;
         Ok(account)
+    }
+
+    pub fn rename_account(&mut self, account_num: u32, new_name: &str) -> Result<(), Error> {
+        self.get_account(account_num)?.set_name(new_name)
     }
 
     pub fn recover_accounts(&mut self, electrum_url: &ElectrumUrl) -> Result<(), Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -102,7 +102,8 @@ impl WalletCtx {
             accounts: Default::default(),
             change_max_deriv: 0,
         };
-        for account_num in store.read()?.account_nums() {
+        let account_nums = store.read()?.account_nums();
+        for account_num in account_nums {
             wallet._ensure_account(account_num)?;
         }
         wallet._ensure_account(0)?;

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -182,7 +182,6 @@ impl WalletCtx {
 
 #[cfg(test)]
 mod test {
-    use crate::interface::p2shwpkh_script_sig;
     use bitcoin::consensus::deserialize;
     use bitcoin::hashes::Hash;
     use bitcoin::secp256k1::{All, Message, Secp256k1, SecretKey};
@@ -192,6 +191,7 @@ mod test {
     use bitcoin::util::key::PublicKey;
     use bitcoin::Script;
     use bitcoin::{Address, Network, Transaction};
+    use gdk_common::scripts::p2shwpkh_script_sig;
     use std::str::FromStr;
 
     fn p2pkh_hex(pk: &str) -> (PublicKey, Script) {

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -12,6 +12,7 @@ extern crate gdk_common;
 use log::{debug, info, trace, warn};
 use serde_json::Value;
 
+pub mod account;
 pub mod error;
 pub mod headers;
 pub mod interface;

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -505,6 +505,12 @@ impl Session<Error> for ElectrumSession {
             }
         };
 
+        // Recover BIP 44 accounts on the first login
+        if !store.read().unwrap().cache.accounts_recovered {
+            wallet.write().unwrap().recover_accounts(&self.url)?;
+            store.write().unwrap().cache.accounts_recovered = true;
+        }
+
         let syncer = Syncer {
             wallet: wallet.clone(),
             store: store.clone(),

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -643,12 +643,12 @@ impl Session<Error> for ElectrumSession {
         self.get_wallet()?.balance(account_num, num_confs)
     }
 
-    fn set_transaction_memo(&self, account_num: u32, txid: &str, memo: &str) -> Result<(), Error> {
+    fn set_transaction_memo(&self, txid: &str, memo: &str) -> Result<(), Error> {
         let txid = BETxid::from_hex(txid, self.network.id())?;
         if memo.len() > 1024 {
             return Err(Error::Generic("Too long memo (max 1024)".into()));
         }
-        self.get_wallet()?.store.write()?.insert_memo(account_num, txid, memo)?;
+        self.get_wallet()?.store.write()?.insert_memo(txid, memo)?;
 
         Ok(())
     }

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -625,6 +625,10 @@ impl Session<Error> for ElectrumSession {
         account.info(0)
     }
 
+    fn rename_subaccount(&mut self, opt: RenameAccountOpt) -> Result<(), Error> {
+        self.get_wallet_mut()?.rename_account(opt.subaccount, &opt.new_name)
+    }
+
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, Error> {
         let txs = self.get_wallet()?.list_tx(opt)?.iter().map(make_txlist_item).collect();
 

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -629,6 +629,10 @@ impl Session<Error> for ElectrumSession {
         self.get_wallet_mut()?.rename_account(opt.subaccount, &opt.new_name)
     }
 
+    fn update_subaccount(&mut self, opt: UpdateAccountOpt) -> Result<(), Error> {
+        self.get_wallet_mut()?.update_account(opt)
+    }
+
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, Error> {
         let txs = self.get_wallet()?.list_tx(opt)?.iter().map(make_txlist_item).collect();
 

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -611,19 +611,18 @@ impl Session<Error> for ElectrumSession {
 
     fn get_subaccounts(&self) -> Result<Vec<AccountInfo>, Error> {
         let wallet = self.get_wallet()?;
-        wallet.iter_accounts().map(|a| a.info()).collect()
+        wallet.iter_accounts().map(|a| a.info(0)).collect()
     }
 
-    fn get_subaccount(&self, account_num: u32, _num_confs: u32) -> Result<AccountInfo, Error> {
-        // TODO num_confs is ignored
+    fn get_subaccount(&self, account_num: u32, num_confs: u32) -> Result<AccountInfo, Error> {
         let wallet = self.get_wallet()?;
-        wallet.get_account(account_num)?.info()
+        wallet.get_account(account_num)?.info(num_confs)
     }
 
     fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, Error> {
         let mut wallet = self.get_wallet_mut()?;
         let account = wallet.create_account(opt)?;
-        account.info()
+        account.info(0)
     }
 
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, Error> {
@@ -636,9 +635,8 @@ impl Session<Error> for ElectrumSession {
         Err(Error::Generic("implementme: ElectrumSession get_transaction_details".into()))
     }
 
-    fn get_balance(&self, _num_confs: u32, account_num: u32) -> Result<Balances, Error> {
-        // TODO num_confs is currently ignored
-        self.get_wallet()?.balance(account_num)
+    fn get_balance(&self, account_num: u32, num_confs: u32) -> Result<Balances, Error> {
+        self.get_wallet()?.balance(account_num, num_confs)
     }
 
     fn set_transaction_memo(&self, account_num: u32, txid: &str, memo: &str) -> Result<(), Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -636,10 +636,9 @@ impl Session<Error> for ElectrumSession {
         Err(Error::Generic("implementme: ElectrumSession get_transaction_details".into()))
     }
 
-    fn get_balance(&self, _num_confs: u32, account_num: Option<u32>) -> Result<Balances, Error> {
+    fn get_balance(&self, _num_confs: u32, account_num: u32) -> Result<Balances, Error> {
         // TODO num_confs is currently ignored
-        // XXX how to handle missing subaccount?
-        self.get_wallet()?.balance(account_num.unwrap_or(0))
+        self.get_wallet()?.balance(account_num)
     }
 
     fn set_transaction_memo(&self, account_num: u32, txid: &str, memo: &str) -> Result<(), Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -649,11 +649,12 @@ impl Session<Error> for ElectrumSession {
     }
 
     fn set_transaction_memo(&self, txid: &str, memo: &str) -> Result<(), Error> {
+        let txid = BETxid::from_hex(txid, self.network.id())?;
         if memo.len() > 1024 {
             return Err(Error::Generic("Too long memo (max 1024)".into()));
         }
-        let txid = BETxid::from_hex(txid, self.network.id())?;
-        self.get_wallet()?.store.write()?.insert_memo(txid, memo)?;
+        // @shesek TODO support multi account
+        self.get_wallet()?.store.write()?.insert_memo(0usize.into(), txid, memo)?;
 
         Ok(())
     }

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -818,13 +818,16 @@ impl Session<Error> for ElectrumSession {
     fn tx_status(&self) -> Result<u64, Error> {
         let mut opt = GetTransactionsOpt::default();
         opt.count = 100;
-        let txs = self.get_wallet()?.list_tx(&opt)?;
         let mut hasher = DefaultHasher::new();
-        for tx in txs.iter() {
-            std::hash::Hash::hash(&tx.txid, &mut hasher);
+        let wallet = self.get_wallet()?;
+        for account in wallet.iter_accounts() {
+            let txs = account.list_tx(&opt)?;
+            for tx in txs.iter() {
+                std::hash::Hash::hash(&tx.txid, &mut hasher);
+            }
         }
         let status = hasher.finish();
-        info!("txs.len={} status={}", txs.len(), status);
+        info!("txs status={}", status);
         Ok(status)
     }
 

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -826,7 +826,7 @@ impl Session<Error> for ElectrumSession {
         opt.count = 100;
         let mut hasher = DefaultHasher::new();
         let wallet = self.get_wallet()?;
-        for account in wallet.iter_accounts() {
+        for account in wallet.iter_accounts_sorted() {
             let txs = account.list_tx(&opt)?;
             for tx in txs.iter() {
                 std::hash::Hash::hash(&tx.txid, &mut hasher);

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -616,6 +616,12 @@ impl Session<Error> for ElectrumSession {
         wallet.get_account(index.into())?.info()
     }
 
+    fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, Error> {
+        let mut wallet = self.get_wallet_mut()?;
+        let account = wallet.create_account(opt)?;
+        account.info()
+    }
+
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, Error> {
         let txs = self.get_wallet()?.list_tx(opt)?.iter().map(make_txlist_item).collect();
 

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -23,7 +23,6 @@ use crate::error::Error;
 use crate::interface::{ElectrumUrl, WalletCtx};
 use crate::store::*;
 
-use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::{self, Secp256k1, SecretKey};
 use bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey};
 
@@ -1040,7 +1039,6 @@ impl Syncer {
         debug!("start sync");
         let start = Instant::now();
 
-        let mut history_txs_id = HashSet::<BETxid>::new();
         let wallet = self.wallet.read().unwrap();
         let mut updated_accounts = HashSet::new();
 

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -47,7 +47,7 @@ pub struct RawCache {
     pub paths: HashMap<BEScript, DerivationPath>,
 
     /// inverse of `paths`
-    pub scripts: HashMap<DerivationPath, BEScript>, // TODO use DerivationPath once Hash gets merged
+    pub scripts: HashMap<DerivationPath, BEScript>,
 
     /// contains only my wallet txs with the relative heights (None if unconfirmed)
     pub heights: HashMap<BETxid, Option<u32>>,
@@ -306,7 +306,6 @@ impl StoreMeta {
         let mut result = ScriptBatch::default();
         result.cached = true;
 
-        //TODO cache m/0 and m/1
         let first_deriv = &self.first_deriv[int_or_ext as usize];
 
         let start = batch * BATCH_SIZE;

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -284,6 +284,10 @@ impl StoreMeta {
             .ok_or_else(|| Error::InvalidSubaccount(account_num.into()))
     }
 
+    pub fn make_account_cache(&mut self, account_num: AccountNum) -> &mut RawAccountCache {
+        self.cache.accounts.entry(account_num).or_default()
+    }
+
     pub fn account_nums(&self) -> HashSet<AccountNum> {
         self.cache.accounts.keys().copied().collect()
     }

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -267,14 +267,14 @@ impl StoreMeta {
         Ok(())
     }
 
-    pub fn account_store(&self, account_num: AccountNum) -> Result<&RawAccountCache, Error> {
+    pub fn account_cache(&self, account_num: AccountNum) -> Result<&RawAccountCache, Error> {
         self.cache
             .accounts
             .get(&account_num)
             .ok_or_else(|| Error::InvalidSubaccount(account_num.into()))
     }
 
-    pub fn account_store_mut(
+    pub fn account_cache_mut(
         &mut self,
         account_num: AccountNum,
     ) -> Result<&mut RawAccountCache, Error> {
@@ -360,7 +360,7 @@ impl StoreMeta {
         account_num: AccountNum,
         txid: &BETxid,
     ) -> SPVVerifyResult {
-        let acc_store = match self.account_store(account_num.into()) {
+        let acc_store = match self.account_cache(account_num.into()) {
             Ok(store) => store,
             Err(_) => return SPVVerifyResult::NotVerified,
         };

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -3,24 +3,18 @@ use crate::spv::CrossValidationResult;
 use crate::Error;
 use aes_gcm_siv::aead::{generic_array::GenericArray, AeadInPlace, NewAead};
 use aes_gcm_siv::Aes256GcmSiv;
-use bitcoin::hashes::sha256;
-use bitcoin::hashes::Hash;
-use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPubKey};
-use bitcoin::{Address, Transaction};
-use elements::AddressParams;
-use gdk_common::be::{
-    BEBlockHash, BEBlockHeader, BEOutPoint, BEScript, BEScriptConvert, BETransaction,
-    BETransactions, BETxid,
-};
-use gdk_common::be::{BETxidConvert, ScriptBatch, Unblinded};
-use gdk_common::error::fn_err;
+use bitcoin::hashes::{sha256, Hash};
+use bitcoin::util::bip32::{DerivationPath, ExtendedPubKey};
+use bitcoin::Transaction;
+use gdk_common::be::{BEBlockHash, BEBlockHeader, BEScript, BETransaction, BETransactions, BETxid};
+use gdk_common::be::{BETxidConvert, Unblinded};
 use gdk_common::model::{FeeEstimate, SPVVerifyResult, Settings};
 use gdk_common::NetworkId;
-use log::{info, trace, warn};
+use log::{info, warn};
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -325,36 +319,6 @@ impl StoreMeta {
         self.write("asset_registry", asset_registry)
     }
 
-    pub fn get_bitcoin_tx(&self, txid: &bitcoin::Txid) -> Result<Transaction, Error> {
-        match self.cache.all_txs.get(&txid.into_be()) {
-            Some(BETransaction::Bitcoin(tx)) => Ok(tx.clone()),
-            _ => Err(Error::Generic("expected bitcoin tx".to_string())),
-        }
-    }
-
-    pub fn get_liquid_tx(&self, txid: &elements::Txid) -> Result<elements::Transaction, Error> {
-        match self.cache.all_txs.get(&txid.into_be()) {
-            Some(BETransaction::Elements(tx)) => Ok(tx.clone()),
-            _ => Err(Error::Generic("expected liquid tx".to_string())),
-        }
-    }
-
-    pub fn spent(&self) -> Result<HashSet<BEOutPoint>, Error> {
-        let mut result = HashSet::new();
-        for tx in self.cache.all_txs.values() {
-            let outpoints: Vec<BEOutPoint> = match tx {
-                BETransaction::Bitcoin(tx) => {
-                    tx.input.iter().map(|i| BEOutPoint::Bitcoin(i.previous_output)).collect()
-                }
-                BETransaction::Elements(tx) => {
-                    tx.input.iter().map(|i| BEOutPoint::Elements(i.previous_output)).collect()
-                }
-            };
-            result.extend(outpoints.into_iter());
-        }
-        Ok(result)
-    }
-
     pub fn fee_estimates(&self) -> Vec<FeeEstimate> {
         if self.cache.fee_estimates.is_empty() {
             let min_fee = match self.id {
@@ -370,6 +334,7 @@ impl StoreMeta {
     pub fn insert_memo(&mut self, txid: BETxid, memo: &str) -> Result<(), Error> {
         // Coerced into a bitcoin::Txid to retain database compatibility
         let txid = txid.into_bitcoin();
+        // @shesek TODO per account
         self.store.memos.insert(txid, memo.to_string());
         self.flush_store()?;
         Ok(())
@@ -403,12 +368,26 @@ impl StoreMeta {
             SPVVerifyResult::Unconfirmed
         }
     }
-}
 
-impl StoreMeta {
     pub fn export_cache(&self) -> Result<RawCache, Error> {
         self.flush_cache()?;
         RawCache::try_new(&self.path, &self.cipher)
+    }
+}
+
+impl RawAccountCache {
+    pub fn get_bitcoin_tx(&self, txid: &bitcoin::Txid) -> Result<Transaction, Error> {
+        match self.all_txs.get(&txid.into_be()) {
+            Some(BETransaction::Bitcoin(tx)) => Ok(tx.clone()),
+            _ => Err(Error::Generic("expected bitcoin tx".to_string())),
+        }
+    }
+
+    pub fn get_liquid_tx(&self, txid: &elements::Txid) -> Result<elements::Transaction, Error> {
+        match self.all_txs.get(&txid.into_be()) {
+            Some(BETransaction::Elements(tx)) => Ok(tx.clone()),
+            _ => Err(Error::Generic("expected liquid tx".to_string())),
+        }
     }
 }
 

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -402,7 +402,8 @@ impl RawAccountCache {
 
 #[cfg(test)]
 mod tests {
-    use crate::store::StoreMeta;
+    use super::*;
+    use bitcoin::hashes::hex::FromHex;
     use bitcoin::util::bip32::ExtendedPubKey;
     use bitcoin::Network;
     use gdk_common::{be::BETxid, NetworkId};
@@ -421,11 +422,17 @@ mod tests {
         )
         .unwrap();
 
-        let mut store = StoreMeta::new(&dir, xpub, None, id).unwrap();
-        store.cache.heights.insert(txid, Some(1));
-        drop(store);
+        let id = NetworkId::Bitcoin(Network::Testnet);
+        let account_num = AccountNum(0);
 
-        let store = StoreMeta::new(&dir, xpub, None, id).unwrap();
-        assert_eq!(store.cache.heights.get(&txid), Some(&Some(1)));
+        {
+            let mut store = StoreMeta::new(&dir, xpub, id).unwrap();
+            let acc_cache = store.account_cache_mut(account_num).unwrap();
+            acc_cache.heights.insert(txid, Some(1));
+        }
+
+        let store = StoreMeta::new(&dir, xpub, id).unwrap();
+        let acc_cache = store.account_cache(account_num).unwrap();
+        assert_eq!(acc_cache.heights.get(&txid), Some(&Some(1)));
     }
 }

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -82,6 +82,9 @@ pub struct RawStore {
     /// wallet settings
     settings: Option<Settings>,
 
+    /// account names
+    account_names: HashMap<AccountNum, String>,
+
     /// transaction memos
     memos: HashMap<AccountNum, HashMap<bitcoin::Txid, String>>,
 }
@@ -342,6 +345,14 @@ impl StoreMeta {
 
     pub fn get_settings(&self) -> Option<Settings> {
         self.store.settings.clone()
+    }
+
+    pub fn get_account_name(&self, account_num: AccountNum) -> Option<&String> {
+        self.store.account_names.get(&account_num)
+    }
+
+    pub fn set_account_name(&mut self, account_num: AccountNum, name: String) {
+        self.store.account_names.insert(account_num, name);
     }
 
     pub fn spv_verification_status(

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -52,6 +52,9 @@ pub struct RawCache {
 
     /// the result of the last spv cross-validation execution
     pub cross_validation_result: Option<CrossValidationResult>,
+
+    /// whether BIP 44 account recovery was already run for this wallet
+    pub accounts_recovered: bool,
 }
 
 #[derive(Default, Serialize, Deserialize)]

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -344,9 +344,12 @@ impl StoreMeta {
         self.store.settings.clone()
     }
 
-    pub fn spv_verification_status(&self, txid: &BETxid) -> SPVVerifyResult {
-        // @shesek TODO support mult account
-        let acc_store = match self.account_store(0usize.into()) {
+    pub fn spv_verification_status(
+        &self,
+        account_num: AccountNum,
+        txid: &BETxid,
+    ) -> SPVVerifyResult {
+        let acc_store = match self.account_store(account_num.into()) {
             Ok(store) => store,
             Err(_) => return SPVVerifyResult::NotVerified,
         };

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -1,3 +1,4 @@
+use crate::account::AccountNum;
 use crate::spv::CrossValidationResult;
 use crate::Error;
 use aes_gcm_siv::aead::{generic_array::GenericArray, AeadInPlace, NewAead};
@@ -7,7 +8,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{All, Secp256k1};
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPubKey};
 use bitcoin::{Address, Transaction};
-use elements::{AddressParams, OutPoint};
+use elements::AddressParams;
 use gdk_common::be::{
     BEBlockHash, BEBlockHeader, BEOutPoint, BEScript, BEScriptConvert, BETransaction,
     BETransactions, BETxid,
@@ -40,7 +41,10 @@ pub type Store = Arc<RwLock<StoreMeta>>;
 /// It is fully reconstructable from xpub and data from electrum server (plus master blinding for elements)
 #[derive(Default, Serialize, Deserialize)]
 pub struct RawCache {
-    /// contains all my tx and all prevouts
+    /// account-specific information (transactions, scripts, history, indexes, unblinded)
+    pub accounts: HashMap<AccountNum, RawAccountCache>,
+
+    /// contains all my tx and all prevouts (@shesek to be removed)
     pub all_txs: BETransactions,
 
     /// contains all my script up to an empty batch of BATCHSIZE
@@ -56,7 +60,7 @@ pub struct RawCache {
     pub headers: HashMap<u32, BEBlockHeader>,
 
     /// unblinded values (only for liquid)
-    pub unblinded: HashMap<OutPoint, Unblinded>,
+    pub unblinded: HashMap<elements::OutPoint, Unblinded>,
 
     /// verification status of Txid (could be only Verified or NotVerified, absence means InProgress)
     pub txs_verif: HashMap<BETxid, SPVVerifyResult>,
@@ -78,6 +82,27 @@ pub struct RawCache {
 
     /// the result of the last spv cross-validation execution
     pub cross_validation_result: Option<CrossValidationResult>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+pub struct RawAccountCache {
+    /// contains all my tx and all prevouts
+    pub all_txs: BETransactions,
+
+    /// contains all my script up to an empty batch of BATCHSIZE
+    pub paths: HashMap<BEScript, DerivationPath>,
+
+    /// inverse of `paths`
+    pub scripts: HashMap<DerivationPath, BEScript>,
+
+    /// contains only my wallet txs with the relative heights (None if unconfirmed)
+    pub heights: HashMap<BETxid, Option<u32>>,
+
+    /// unblinded values (only for liquid)
+    pub unblinded: HashMap<elements::OutPoint, Unblinded>,
+
+    /// max used indexes for external derivation /0/* and internal derivation /1/* (change)
+    pub indexes: Indexes,
 }
 
 /// RawStore contains data that are not extractable from xpub+blockchain
@@ -280,6 +305,23 @@ impl StoreMeta {
         file.write(&vec)?;
         info!("end write {} bytes to {}", vec.len(), name);
         Ok(())
+    }
+
+    pub fn account_store(&self, account_num: AccountNum) -> Result<&RawAccountCache, Error> {
+        self.cache
+            .accounts
+            .get(&account_num)
+            .ok_or_else(|| Error::InvalidSubaccount(account_num.into()))
+    }
+
+    pub fn account_store_mut(
+        &mut self,
+        account_num: AccountNum,
+    ) -> Result<&mut RawAccountCache, Error> {
+        self.cache
+            .accounts
+            .get_mut(&account_num)
+            .ok_or_else(|| Error::InvalidSubaccount(account_num.into()))
     }
 
     pub fn read_asset_icons(&self) -> Result<Option<Value>, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -83,7 +83,7 @@ pub struct RawStore {
     settings: Option<Settings>,
 
     /// transaction memos
-    memos: HashMap<bitcoin::Txid, String>,
+    memos: HashMap<AccountNum, HashMap<bitcoin::Txid, String>>,
 }
 
 pub struct StoreMeta {
@@ -317,18 +317,21 @@ impl StoreMeta {
         }
     }
 
-    pub fn insert_memo(&mut self, txid: BETxid, memo: &str) -> Result<(), Error> {
+    pub fn insert_memo(
+        &mut self,
+        account_num: AccountNum,
+        txid: BETxid,
+        memo: &str,
+    ) -> Result<(), Error> {
         // Coerced into a bitcoin::Txid to retain database compatibility
         let txid = txid.into_bitcoin();
-        // @shesek TODO per account
-        self.store.memos.insert(txid, memo.to_string());
+        self.store.memos.entry(account_num).or_default().insert(txid, memo.to_string());
         self.flush_store()?;
         Ok(())
     }
 
-    pub fn get_memo(&self, txid: &BETxid) -> Option<&String> {
-        // Coerced into a bitcoin::Txid to retain database compatibility
-        self.store.memos.get(&txid.into_bitcoin())
+    pub fn get_memo(&self, account_num: AccountNum, txid: &BETxid) -> Option<&String> {
+        self.store.memos.get(&account_num).and_then(|a| a.get(&txid.into_bitcoin()))
     }
 
     pub fn insert_settings(&mut self, settings: Option<Settings>) -> Result<(), Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -183,12 +183,14 @@ impl StoreMeta {
         let key_bytes = sha256::Hash::hash(&enc_key_data).into_inner();
         let key = GenericArray::from_slice(&key_bytes);
         let cipher = Aes256GcmSiv::new(&key);
-        let cache = RawCache::new(path.as_ref(), &cipher);
+        let mut cache = RawCache::new(path.as_ref(), &cipher);
         let store = RawStore::new(path.as_ref(), &cipher);
         let path = path.as_ref().to_path_buf();
         if !path.exists() {
             std::fs::create_dir_all(&path)?;
         }
+
+        cache.accounts.entry(0).or_default();
 
         Ok(StoreMeta {
             cache,

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -88,7 +88,7 @@ pub struct RawStore {
     account_names: HashMap<u32, String>,
 
     /// transaction memos (account_num -> txid -> memo)
-    memos: HashMap<u32, HashMap<bitcoin::Txid, String>>,
+    memos: HashMap<bitcoin::Txid, String>,
 }
 
 pub struct StoreMeta {
@@ -320,16 +320,16 @@ impl StoreMeta {
         }
     }
 
-    pub fn insert_memo(&mut self, account_num: u32, txid: BETxid, memo: &str) -> Result<(), Error> {
+    pub fn insert_memo(&mut self, txid: BETxid, memo: &str) -> Result<(), Error> {
         // Coerced into a bitcoin::Txid to retain database compatibility
         let txid = txid.into_bitcoin();
-        self.store.memos.entry(account_num).or_default().insert(txid, memo.to_string());
+        self.store.memos.insert(txid, memo.to_string());
         self.flush_store()?;
         Ok(())
     }
 
-    pub fn get_memo(&self, account_num: u32, txid: &BETxid) -> Option<&String> {
-        self.store.memos.get(&account_num).and_then(|a| a.get(&txid.into_bitcoin()))
+    pub fn get_memo(&self, txid: &BETxid) -> Option<&String> {
+        self.store.memos.get(&txid.into_bitcoin())
     }
 
     pub fn insert_settings(&mut self, settings: Option<Settings>) -> Result<(), Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/store.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/store.rs
@@ -5,7 +5,6 @@ use aes_gcm_siv::aead::{generic_array::GenericArray, AeadInPlace, NewAead};
 use aes_gcm_siv::Aes256GcmSiv;
 use bitcoin::hashes::sha256;
 use bitcoin::hashes::Hash;
-use bitcoin::secp256k1::{All, Secp256k1};
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPubKey};
 use bitcoin::{Address, Transaction};
 use elements::AddressParams;
@@ -16,11 +15,7 @@ use gdk_common::be::{
 use gdk_common::be::{BETxidConvert, ScriptBatch, Unblinded};
 use gdk_common::error::fn_err;
 use gdk_common::model::{FeeEstimate, SPVVerifyResult, Settings};
-use gdk_common::scripts::p2shwpkh_script;
-use gdk_common::wally::{
-    asset_blinding_key_to_ec_private_key, ec_public_key_from_private_key, MasterBlindingKey,
-};
-use gdk_common::{ElementsNetwork, NetworkId};
+use gdk_common::NetworkId;
 use log::{info, trace, warn};
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
@@ -29,7 +24,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
@@ -119,12 +113,9 @@ pub struct RawStore {
 pub struct StoreMeta {
     pub cache: RawCache,
     pub store: RawStore,
-    master_blinding: Option<MasterBlindingKey>,
-    secp: Secp256k1<All>,
     id: NetworkId,
     path: PathBuf,
     cipher: Aes256GcmSiv,
-    first_deriv: [ExtendedPubKey; 2],
 }
 
 impl Drop for StoreMeta {
@@ -202,7 +193,6 @@ impl StoreMeta {
     pub fn new<P: AsRef<Path>>(
         path: P,
         xpub: ExtendedPubKey,
-        master_blinding: Option<MasterBlindingKey>,
         id: NetworkId,
     ) -> Result<StoreMeta, Error> {
         let mut enc_key_data = vec![];
@@ -218,22 +208,13 @@ impl StoreMeta {
         if !path.exists() {
             std::fs::create_dir_all(&path)?;
         }
-        let secp = Secp256k1::new();
-
-        let first_deriv = [
-            xpub.derive_pub(&secp, &[ChildNumber::from(0)])?,
-            xpub.derive_pub(&secp, &[ChildNumber::from(1)])?,
-        ];
 
         Ok(StoreMeta {
             cache,
             store,
-            master_blinding,
             id,
             cipher,
-            secp,
             path,
-            first_deriv,
         })
     }
 
@@ -342,72 +323,6 @@ impl StoreMeta {
     /// it is stored out of the encrypted area since it's public info
     pub fn write_asset_registry(&self, asset_registry: &Value) -> Result<(), Error> {
         self.write("asset_registry", asset_registry)
-    }
-
-    pub fn get_script_batch(&self, int_or_ext: u32, batch: u32) -> Result<ScriptBatch, Error> {
-        let mut result = ScriptBatch::default();
-        result.cached = true;
-
-        let first_deriv = &self.first_deriv[int_or_ext as usize];
-
-        let start = batch * BATCH_SIZE;
-        let end = start + BATCH_SIZE;
-        for j in start..end {
-            let path = DerivationPath::from_str(&format!("m/{}/{}", int_or_ext, j))?;
-            let opt_script = self.cache.scripts.get(&path);
-            let script = match opt_script {
-                Some(script) => script.clone(),
-                None => {
-                    result.cached = false;
-                    let second_path = [ChildNumber::from(j)];
-                    let second_deriv = first_deriv.derive_pub(&self.secp, &second_path)?;
-                    // Note we are using regtest here because we are not interested in the address, only in script construction
-                    let script: BEScript = match self.id {
-                        NetworkId::Bitcoin(network) => {
-                            let address =
-                                Address::p2shwpkh(&second_deriv.public_key, network).unwrap();
-                            trace!("{}/{} {}", int_or_ext as u32, j, address);
-                            address.script_pubkey().into()
-                        }
-                        NetworkId::Elements(network) => {
-                            let params = match network {
-                                ElementsNetwork::Liquid => &AddressParams::LIQUID,
-                                ElementsNetwork::ElementsRegtest => &AddressParams::ELEMENTS,
-                            };
-
-                            let script = p2shwpkh_script(&second_deriv.public_key).into_elements();
-                            let blinding_key = asset_blinding_key_to_ec_private_key(
-                                self.master_blinding.as_ref().ok_or_else(fn_err(
-                                    "missing master blinding in elements session",
-                                ))?,
-                                &script,
-                            );
-                            let public_key = ec_public_key_from_private_key(blinding_key);
-                            let blinder = Some(public_key);
-
-                            let address = elements::Address::p2shwpkh(
-                                &second_deriv.public_key,
-                                blinder,
-                                params,
-                            );
-                            trace!(
-                                "{}/{} blinded address {}  blinder {:?}",
-                                int_or_ext as u32,
-                                j,
-                                address,
-                                blinder
-                            );
-                            assert_eq!(script, address.script_pubkey());
-                            address.script_pubkey().into()
-                        }
-                    };
-
-                    script
-                }
-            };
-            result.value.push((script, path));
-        }
-        Ok(result)
     }
 
     pub fn get_bitcoin_tx(&self, txid: &bitcoin::Txid) -> Result<Transaction, Error> {

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -403,17 +403,16 @@ where
 
         "get_receive_address" => {
             let a = session
-                .get_receive_address(input)
+                .get_receive_address(&serde_json::from_value(input.clone())?)
                 .map(|x| serde_json::to_value(&x).unwrap())
                 .map_err(Into::into);
             info!("gdk_rust get_receive_address returning {:?}", a);
             a
         }
 
-        "get_mnemonic" => session
-            .get_mnemonic()
-            .map(|m| Value::String(m.clone().get_mnemonic_str()))
-            .map_err(Into::into),
+        "get_mnemonic" => {
+            session.get_mnemonic().map(|m| Value::String(m.get_mnemonic_str())).map_err(Into::into)
+        }
 
         "get_fee_estimates" => {
             session.get_fee_estimates().map_err(Into::into).and_then(|x| fee_estimate_values(&x))
@@ -430,9 +429,10 @@ where
             .refresh_assets(&serde_json::from_value(input.clone())?)
             .map(|v| json!(v))
             .map_err(Into::into),
-        "get_unspent_outputs" => {
-            session.get_unspent_outputs(input).map(|v| json!(v)).map_err(Into::into)
-        }
+        "get_unspent_outputs" => session
+            .get_unspent_outputs(&serde_json::from_value(input.clone())?)
+            .map(|v| json!(v))
+            .map_err(Into::into),
 
         // "auth_handler_get_status" => Ok(auth_handler.to_json()),
         _ => Err(Error::Other(format!("handle_call method not found: {}", method))),

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -22,7 +22,7 @@ use std::os::raw::c_char;
 use std::sync::Once;
 use std::time::{Duration, SystemTime};
 
-use gdk_common::model::{GDKRUST_json, GetTransactionsOpt, SPVVerifyTx};
+use gdk_common::model::{CreateAccountOpt, GDKRUST_json, GetTransactionsOpt, SPVVerifyTx};
 use gdk_common::session::Session;
 
 use crate::error::Error;
@@ -374,6 +374,14 @@ where
         }
 
         "get_subaccount" => get_subaccount(session, input),
+
+        "create_subaccount" => {
+            let opt: CreateAccountOpt = serde_json::from_value(input.clone())?;
+            session
+                .create_subaccount(opt)
+                .map(|x| serialize::subaccount_value(&x))
+                .map_err(Into::into)
+        }
 
         "get_transactions" => {
             let opt: GetTransactionsOpt = serde_json::from_value(input.clone())?;

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -22,7 +22,9 @@ use std::os::raw::c_char;
 use std::sync::Once;
 use std::time::{Duration, SystemTime};
 
-use gdk_common::model::{CreateAccountOpt, GDKRUST_json, GetTransactionsOpt, SPVVerifyTx};
+use gdk_common::model::{
+    CreateAccountOpt, GDKRUST_json, GetTransactionsOpt, RenameAccountOpt, SPVVerifyTx,
+};
 use gdk_common::session::Session;
 
 use crate::error::Error;
@@ -381,6 +383,10 @@ where
                 .create_subaccount(opt)
                 .map(|x| serialize::subaccount_value(&x))
                 .map_err(Into::into)
+        }
+        "rename_subaccount" => {
+            let opt: RenameAccountOpt = serde_json::from_value(input.clone())?;
+            session.rename_subaccount(opt).map(|_| json!(true)).map_err(Into::into)
         }
 
         "get_transactions" => {

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, SystemTime};
 
 use gdk_common::model::{
     CreateAccountOpt, GDKRUST_json, GetTransactionsOpt, RenameAccountOpt, SPVVerifyTx,
+    UpdateAccountOpt,
 };
 use gdk_common::session::Session;
 
@@ -387,6 +388,10 @@ where
         "rename_subaccount" => {
             let opt: RenameAccountOpt = serde_json::from_value(input.clone())?;
             session.rename_subaccount(opt).map(|_| json!(true)).map_err(Into::into)
+        }
+        "update_subaccount" => {
+            let opt: UpdateAccountOpt = serde_json::from_value(input.clone())?;
+            session.update_subaccount(opt).map(|_| json!(true)).map_err(Into::into)
         }
 
         "get_transactions" => {

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -82,11 +82,11 @@ pub fn txs_result_value(txs: &TxsResult) -> Value {
     Value::Array(txs.0.iter().map(txitem_value).collect())
 }
 
-pub fn subaccounts_value(subaccounts: &[Subaccount]) -> Value {
+pub fn subaccounts_value(subaccounts: &[AccountInfo]) -> Value {
     Value::Array(subaccounts.iter().map(subaccount_value).collect())
 }
 
-pub fn subaccount_value(subaccount: &Subaccount) -> Value {
+pub fn subaccount_value(subaccount: &AccountInfo) -> Value {
     json!({
         "type": subaccount.type_,
         "pointer": 0,

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -88,7 +88,7 @@ pub fn subaccounts_value(subaccounts: &[AccountInfo]) -> Value {
 
 pub fn subaccount_value(subaccount: &AccountInfo) -> Value {
     json!({
-        "type": subaccount.type_,
+        "type": subaccount.script_type,
         "pointer": 0,
         "required_ca": 0,
         "receiving_id": "",

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -202,12 +202,6 @@ where
     E: Into<Error>,
     S: Session<E>,
 {
-    // XXX how to handle missing subaccount?
-    let account_num = input["subaccount"]
-        .as_u64()
-        .ok_or_else(|| Error::Other("get_transaction_details: missing subaccount".into()))?
-        as u32;
-
     // TODO: parse txid?.
     let txid = input["txid"]
         .as_str()
@@ -217,7 +211,7 @@ where
         .as_str()
         .ok_or_else(|| Error::Other("get_transaction_details: missing memo".into()))?;
 
-    session.set_transaction_memo(account_num, txid, memo).map(|v| json!(v)).map_err(Into::into)
+    session.set_transaction_memo(txid, memo).map(|v| json!(v)).map_err(Into::into)
 }
 
 pub fn get_balance<S, E>(session: &S, input: &Value) -> Result<Value, Error>

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -92,7 +92,8 @@ pub fn subaccount_value(subaccount: &AccountInfo) -> Value {
         "pointer": 0,
         "required_ca": 0,
         "receiving_id": "",
-        "name": subaccount.name,
+        "name": subaccount.settings.name,
+        "hidden": subaccount.settings.hidden,
         "has_transactions": subaccount.has_transactions,
         "satoshi": balance_result_value(&subaccount.satoshi)
     })

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -227,7 +227,10 @@ where
 {
     let num_confs = input["num_confs"].as_u64().unwrap_or(0);
 
-    let subaccount = input["subaccount"].as_u64().map(|x| x as u32);
+    let subaccount = input["subaccount"]
+        .as_u64()
+        .ok_or_else(|| Error::Other("get_balance: missing subaccount".into()))?
+        as u32;
 
     let bal = session.get_balance(num_confs as u32, subaccount).map_err(Into::into)?;
 

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -202,6 +202,12 @@ where
     E: Into<Error>,
     S: Session<E>,
 {
+    // XXX how to handle missing subaccount?
+    let account_num = input["subaccount"]
+        .as_u64()
+        .ok_or_else(|| Error::Other("get_transaction_details: missing subaccount".into()))?
+        as u32;
+
     // TODO: parse txid?.
     let txid = input["txid"]
         .as_str()
@@ -211,7 +217,7 @@ where
         .as_str()
         .ok_or_else(|| Error::Other("get_transaction_details: missing memo".into()))?;
 
-    session.set_transaction_memo(txid, memo).map(|v| json!(v)).map_err(Into::into)
+    session.set_transaction_memo(account_num, txid, memo).map(|v| json!(v)).map_err(Into::into)
 }
 
 pub fn get_balance<S, E>(session: &S, input: &Value) -> Result<Value, Error>

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -232,7 +232,7 @@ where
         .ok_or_else(|| Error::Other("get_balance: missing subaccount".into()))?
         as u32;
 
-    let bal = session.get_balance(num_confs as u32, subaccount).map_err(Into::into)?;
+    let bal = session.get_balance(subaccount, num_confs as u32).map_err(Into::into)?;
 
     Ok(balance_result_value(&bal))
 }

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -193,7 +193,7 @@ fn spv_cross_validation_session() {
     let (mut test_session1, mut test_session2) = setup_forking_sessions(true);
 
     // Send a payment to session1
-    let ap = test_session1.session.get_receive_address(&serde_json::Value::Null).unwrap();
+    let ap = test_session1.get_receive_address(0);
     let txid = test_session1.node_sendtoaddress(&ap.address, 999999, None);
     test_session1.wait_tx_status_change();
     let txitem = test_session1.get_tx_from_list(&txid);

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -194,14 +194,14 @@ fn subaccounts() {
         test_session.send_all_from_account(2, &test_session.get_receive_address(1).address, None);
     test_session.wait_account_tx(1, &txid);
     assert_eq!(test_session.balance_account(0, None), 0);
-    assert_eq!(test_session.balance_account(1, None), 166470);
+    assert_eq!(test_session.balance_account(1, None), 166471);
     assert_eq!(test_session.balance_account(2, None), 0);
 
     // Send from account #1 to account #0 (p2wpkh -> p2sh-p2wpkh)
     let txid = test_session.send_tx_from(1, &acc0_address.address, 11555, None);
     test_session.wait_account_tx(0, &txid);
     assert_eq!(test_session.balance_account(0, None), 11555);
-    assert_eq!(test_session.balance_account(1, None), 154771);
+    assert_eq!(test_session.balance_account(1, None), 154772);
 
     // Send from account #0 to account #2 (p2sh-p2wpkh -> p2pkh)
     let txid =

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -211,7 +211,7 @@ fn subaccounts() {
     assert_eq!(test_session.balance_account(2, None), 1000);
 
     // Should use the next available P2PKH account numbers, skipping over used and reserved numbers
-    for expected_pkh_num in &[10u32, 18] {
+    for expected_pkh_num in &[18u32, 34] {
         let account = test_session
             .session
             .create_subaccount(CreateAccountOpt {

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -52,12 +52,12 @@ fn bitcoin() {
     test_session.reconnect();
     test_session.spv_verify_tx(&txid, 102);
     test_session.test_set_get_memo(&txid, MEMO2, ""); // after reconnect memo has been reloaded from disk
-    let mut utxos = test_session.utxo("btc", vec![149741, 96697489]);
+    let mut utxos = test_session.utxo("btc", vec![149739, 96697483]);
     test_session.check_decryption(103, &[&txid]);
 
-    utxos.0.get_mut("btc").unwrap().retain(|e| e.satoshi == 149741); // we want to use the smallest utxo
+    utxos.0.get_mut("btc").unwrap().retain(|e| e.satoshi == 149739); // we want to use the smallest utxo
     test_session.send_tx(&node_legacy_address, 10_000, None, None, Some(utxos));
-    test_session.utxo("btc", vec![139573, 96697489]); // the smallest utxo has been spent
+    test_session.utxo("btc", vec![139569, 96697483]); // the smallest utxo has been spent
                                                       // TODO add a test with external UTXO
 
     test_session.stop();

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -508,7 +508,7 @@ fn setup_session(
     env::var("WALLY_DIR").expect("env WALLY_DIR directory containing libwally is required");
     let debug = env::var("DEBUG").is_ok();
 
-    test_session::setup(false, debug, &electrs_exec, &node_exec, num_client, network_conf)
+    test_session::setup(is_liquid, debug, &electrs_exec, &node_exec, num_client, network_conf)
 }
 
 fn get_chain(test_session: &mut TestSession) -> HeadersChain {

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -1,4 +1,4 @@
-use gdk_common::model::{CreateAccountOpt, RefreshAssets, SPVVerifyResult};
+use gdk_common::model::{CreateAccountOpt, RefreshAssets, RenameAccountOpt, SPVVerifyResult};
 use gdk_common::scripts::ScriptType;
 use gdk_common::session::Session;
 use gdk_electrum::error::Error;
@@ -168,6 +168,16 @@ fn subaccounts() {
     assert_eq!(account2.script_type, ScriptType::P2pkh);
     assert_eq!(test_session.session.get_subaccount(1, 0).unwrap().script_type, ScriptType::P2wpkh);
     assert_eq!(test_session.session.get_subaccount(2, 0).unwrap().name, "Account 2");
+
+    // Rename subaccount
+    test_session
+        .session
+        .rename_subaccount(RenameAccountOpt {
+            subaccount: 2,
+            new_name: "Account 2@".into(),
+        })
+        .unwrap();
+    assert_eq!(test_session.session.get_subaccount(2, 0).unwrap().name, "Account 2@");
 
     // Get addresses & check they match the expected types
     let acc0_address = test_session.get_receive_address(0);

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -995,7 +995,7 @@ impl TestSession {
     pub fn check_decryption(&mut self, tip: u32, txids: &[&str]) {
         let cache = self.session.export_cache().unwrap();
         assert_eq!(cache.tip.0, tip);
-        let account0 = cache.accounts.get(&0u32.into()).expect("default account");
+        let account0 = cache.accounts.get(&0).expect("default account");
         for txid in txids {
             assert!(account0
                 .all_txs

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -358,7 +358,7 @@ impl TestSession {
         //let init_sat = self.balance_gdk();
         //let init_sat_addr = self.balance_addr(address);
         let mut create_opt = CreateTransaction::default();
-        create_opt.subaccount = Some(subaccount);
+        create_opt.subaccount = subaccount;
         let fee_rate = 1000;
         create_opt.fee_rate = Some(fee_rate);
         create_opt.addressees.push(AddressAmount {
@@ -461,7 +461,7 @@ impl TestSession {
         asset: Option<String>,
     ) -> String {
         let mut create_opt = CreateTransaction::default();
-        create_opt.subaccount = Some(subaccount);
+        create_opt.subaccount = subaccount;
         let fee_rate = match self.network.id() {
             NetworkId::Elements(_) => 100,
             NetworkId::Bitcoin(_) => 1000,
@@ -664,12 +664,12 @@ impl TestSession {
             Err(Error::InsufficientFunds)
         ));
 
-        create_opt.subaccount = Some(1);
+        create_opt.subaccount = 99;
         assert!(matches!(
             self.session.create_transaction(&mut create_opt),
-            Err(Error::InvalidSubaccount(1))
+            Err(Error::InvalidSubaccount(99))
         ));
-        create_opt.subaccount = None;
+        create_opt.subaccount = 0;
 
         create_opt.previous_transaction.insert("txhash".into(), "something".into());
         assert!(matches!(self.session.create_transaction(&mut create_opt), Err(Error::Generic(_))));
@@ -898,7 +898,7 @@ impl TestSession {
 
     /// balance in satoshi (or liquid satoshi) of the gdk session for account 0
     fn balance_gdk_all(&self) -> Balances {
-        self.session.get_balance(0, None).unwrap()
+        self.session.get_balance(0, 0).unwrap()
     }
 
     /// balance in satoshi (or liquid satoshi) of the gdk session for account 0
@@ -907,7 +907,7 @@ impl TestSession {
     }
 
     pub fn balance_account(&self, account_num: u32, asset: Option<String>) -> u64 {
-        let balance = self.session.get_balance(0, Some(account_num)).unwrap();
+        let balance = self.session.get_balance(account_num, 0).unwrap();
         match self.network_id {
             NetworkId::Elements(_) => {
                 let asset =

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -270,6 +270,7 @@ pub fn setup(
 impl TestSession {
     /// wait gdk session block status to change (max 1 min)
     pub fn wait_tx_status_change(&mut self) {
+        self.tx_status = self.session.tx_status().unwrap();
         for _ in 0..120 {
             if let Ok(new_status) = self.session.tx_status() {
                 if self.tx_status != new_status {

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -268,6 +268,10 @@ pub fn setup(
 
 // NOTE: Methods that don't accept an explicit account number operate on account #0
 impl TestSession {
+    pub fn network(&self) -> &Network {
+        &self.network
+    }
+
     /// wait gdk session block status to change (max 1 min)
     pub fn wait_tx_status_change(&mut self) {
         self.tx_status = self.session.tx_status().unwrap();

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -873,6 +873,10 @@ impl TestSession {
         }
     }
 
+    pub fn account_btc_balance(&self, account_num: u32) -> u64 {
+        *self.session.get_balance(0, Some(account_num)).unwrap().get("btc").unwrap() as u64
+    }
+
     pub fn spv_verify_tx(&self, txid: &str, height: u32) {
         let temp_dir = TempDir::new("electrum_integration_tests").unwrap();
         let temp_dir_str = format!("{}", &temp_dir.path().display());


### PR DESCRIPTION
- Support multiple subaccounts under the root wallet seed
- Subaccounts can have different script types: P2WPKH, P2SH-P2WPKH or P2KH
- Different script types are mapped into different non-overlapping sets of subaccount numbers
- Fixes querying for wallet utxos/balance with a `num_confs` parameter
- Includes BIP44 subaccount recovery
- Includes a new `rename_account` session method (didn't exists previously and isn't used by AQUA)
- Includes some tests

TODO:
- [x] Database migration for existing user labels