### PR TITLE
Expose twofactor reset undo functionality

### DIFF
--- a/include/gdk.h
+++ b/include/gdk.h
@@ -740,6 +740,21 @@ GDK_API int GA_twofactor_reset(
     struct GA_session* session, const char* email, uint32_t is_dispute, struct GA_auth_handler** call);
 
 /**
+ * Undo a request to begin the two factor authentication reset process.
+ *
+ * :param session: The session to use.
+ * :param email: The email address to cancel the reset request for. Must be
+ *|     the email previously passed to `GA_twofactor_reset`.
+ * :param call: Destination for the resulting GA_auth_handler to request the reset.
+ *|     Returned GA_auth_handler should be freed using `GA_destroy_auth_handler`.
+ *
+ * .. note:: Unlike`GA_twofactor_cancel_reset`, this call only removes the reset
+ *|     request associated with the given email. If other emails have requested
+ *|     a reset, the wallet will still remain locked following this call.
+ */
+GDK_API int GA_twofactor_undo_reset(struct GA_session* session, const char* email, struct GA_auth_handler** call);
+
+/**
  * Cancel all outstanding two factor resets and unlock the wallet for normal operation.
  *
  * :param session: The session to use.

--- a/src/ffi_c.cpp
+++ b/src/ffi_c.cpp
@@ -394,8 +394,17 @@ GDK_DEFINE_C_FUNCTION_4(GA_change_settings_twofactor, struct GA_session*, sessio
     })
 
 GDK_DEFINE_C_FUNCTION_4(GA_twofactor_reset, struct GA_session*, session, const char*, email, uint32_t, is_dispute,
-    struct GA_auth_handler**, call,
-    { *call = auth_cast(new ga::sdk::twofactor_reset_call(*session, email, is_dispute != GA_FALSE)); });
+    struct GA_auth_handler**, call, {
+        constexpr bool is_undo = false;
+        *call = auth_cast(new ga::sdk::twofactor_reset_call(*session, email, is_dispute != GA_FALSE, is_undo));
+    });
+
+GDK_DEFINE_C_FUNCTION_3(
+    GA_twofactor_undo_reset, struct GA_session*, session, const char*, email, struct GA_auth_handler**, call, {
+        constexpr bool is_dispute = false; // Irrelevant for undo
+        constexpr bool is_undo = true;
+        *call = auth_cast(new ga::sdk::twofactor_reset_call(*session, email, is_dispute, is_undo));
+    });
 
 GDK_DEFINE_C_FUNCTION_2(GA_twofactor_cancel_reset, struct GA_session*, session, struct GA_auth_handler**, call,
     { *call = auth_cast(new ga::sdk::twofactor_cancel_reset_call(*session)); });

--- a/src/ga_auth_handlers.hpp
+++ b/src/ga_auth_handlers.hpp
@@ -267,13 +267,14 @@ namespace sdk {
 
     class twofactor_reset_call : public auth_handler {
     public:
-        twofactor_reset_call(session& session, const std::string& email, bool is_dispute);
+        twofactor_reset_call(session& session, const std::string& email, bool is_dispute, bool is_undo);
 
     private:
         state_type call_impl() override;
 
-        std::string m_reset_email;
-        bool m_is_dispute;
+        const std::string m_reset_email;
+        const bool m_is_dispute;
+        const bool m_is_undo;
         bool m_confirming;
     };
 

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -337,10 +337,17 @@ namespace sdk {
         return std::string{};
     }
 
-    nlohmann::json ga_rust::reset_twofactor(const std::string& email) { return nlohmann::json{}; }
+    nlohmann::json ga_rust::request_twofactor_reset(const std::string& email) { return nlohmann::json{}; }
 
     nlohmann::json ga_rust::confirm_twofactor_reset(
         const std::string& email, bool is_dispute, const nlohmann::json& twofactor_data)
+    {
+        return nlohmann::json{};
+    }
+
+    nlohmann::json ga_rust::request_undo_twofactor_reset(const std::string& email) { return nlohmann::json{}; }
+
+    nlohmann::json ga_rust::confirm_undo_twofactor_reset(const std::string& email, const nlohmann::json& twofactor_data)
     {
         return nlohmann::json{};
     }

--- a/src/ga_rust.hpp
+++ b/src/ga_rust.hpp
@@ -128,10 +128,16 @@ namespace sdk {
         void auth_handler_request_code(
             const std::string& method, const std::string& action, const nlohmann::json& twofactor_data);
         std::string auth_handler_request_proxy_code(const std::string& action, const nlohmann::json& twofactor_data);
-        nlohmann::json reset_twofactor(const std::string& email);
+
+        nlohmann::json request_twofactor_reset(const std::string& email);
         nlohmann::json confirm_twofactor_reset(
             const std::string& email, bool is_dispute, const nlohmann::json& twofactor_data);
+
+        nlohmann::json request_undo_twofactor_reset(const std::string& email);
+        nlohmann::json confirm_undo_twofactor_reset(const std::string& email, const nlohmann::json& twofactor_data);
+
         nlohmann::json cancel_twofactor_reset(const nlohmann::json& twofactor_data);
+
         nlohmann::json set_pin(const std::string& mnemonic, const std::string& pin, const std::string& device_id);
 
         nlohmann::json get_unspent_outputs(const nlohmann::json& details);

--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -3422,9 +3422,15 @@ namespace sdk {
     }
 
     // Idempotent
-    nlohmann::json ga_session::reset_twofactor(const std::string& email)
+    nlohmann::json ga_session::request_twofactor_reset(const std::string& email)
     {
         return wamp_cast_json(wamp_call("twofactor.request_reset", email));
+    }
+
+    // Idempotent
+    nlohmann::json ga_session::request_undo_twofactor_reset(const std::string& email)
+    {
+        return wamp_cast_json(wamp_call("twofactor.request_undo_reset", email));
     }
 
     // Idempotent
@@ -3432,6 +3438,14 @@ namespace sdk {
         const std::string& email, bool is_dispute, const nlohmann::json& twofactor_data)
     {
         auto result = wamp_call("twofactor.confirm_reset", email, is_dispute, mp_cast(twofactor_data).get());
+        return wamp_cast_json(result);
+    }
+
+    // Idempotent
+    nlohmann::json ga_session::confirm_undo_twofactor_reset(
+        const std::string& email, const nlohmann::json& twofactor_data)
+    {
+        auto result = wamp_call("twofactor.confirm_undo_reset", email, mp_cast(twofactor_data).get());
         return wamp_cast_json(result);
     }
 

--- a/src/ga_session.hpp
+++ b/src/ga_session.hpp
@@ -228,9 +228,14 @@ namespace sdk {
         void auth_handler_request_code(
             const std::string& method, const std::string& action, const nlohmann::json& twofactor_data);
         std::string auth_handler_request_proxy_code(const std::string& action, const nlohmann::json& twofactor_data);
-        nlohmann::json reset_twofactor(const std::string& email);
+
+        nlohmann::json request_twofactor_reset(const std::string& email);
         nlohmann::json confirm_twofactor_reset(
             const std::string& email, bool is_dispute, const nlohmann::json& twofactor_data);
+
+        nlohmann::json request_undo_twofactor_reset(const std::string& email);
+        nlohmann::json confirm_undo_twofactor_reset(const std::string& email, const nlohmann::json& twofactor_data);
+
         nlohmann::json cancel_twofactor_reset(const nlohmann::json& twofactor_data);
 
         nlohmann::json set_pin(const std::string& mnemonic, const std::string& pin, const std::string& device_id);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -688,11 +688,11 @@ namespace sdk {
         });
     }
 
-    nlohmann::json session::reset_twofactor(const std::string& email)
+    nlohmann::json session::request_twofactor_reset(const std::string& email)
     {
         return exception_wrapper([&] {
             auto p = get_nonnull_impl();
-            return p->reset_twofactor(email);
+            return p->request_twofactor_reset(email);
         });
     }
 
@@ -702,6 +702,22 @@ namespace sdk {
         return exception_wrapper([&] {
             auto p = get_nonnull_impl();
             return p->confirm_twofactor_reset(email, is_dispute, twofactor_data);
+        });
+    }
+
+    nlohmann::json session::request_undo_twofactor_reset(const std::string& email)
+    {
+        return exception_wrapper([&] {
+            auto p = get_nonnull_impl();
+            return p->request_undo_twofactor_reset(email);
+        });
+    }
+
+    nlohmann::json session::confirm_undo_twofactor_reset(const std::string& email, const nlohmann::json& twofactor_data)
+    {
+        return exception_wrapper([&] {
+            auto p = get_nonnull_impl();
+            return p->confirm_undo_twofactor_reset(email, twofactor_data);
         });
     }
 

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -119,9 +119,14 @@ namespace sdk {
         void auth_handler_request_code(
             const std::string& method, const std::string& action, const nlohmann::json& twofactor_data);
         std::string auth_handler_request_proxy_code(const std::string& action, const nlohmann::json& twofactor_data);
-        nlohmann::json reset_twofactor(const std::string& email);
+
+        nlohmann::json request_twofactor_reset(const std::string& email);
         nlohmann::json confirm_twofactor_reset(
             const std::string& email, bool is_dispute, const nlohmann::json& twofactor_data);
+
+        nlohmann::json request_undo_twofactor_reset(const std::string& email);
+        nlohmann::json confirm_undo_twofactor_reset(const std::string& email, const nlohmann::json& twofactor_data);
+
         nlohmann::json cancel_twofactor_reset(const nlohmann::json& twofactor_data);
 
         nlohmann::json set_pin(const std::string& mnemonic, const std::string& pin, const std::string& device_id);

--- a/src/session_common.hpp
+++ b/src/session_common.hpp
@@ -117,10 +117,16 @@ namespace sdk {
         virtual std::string auth_handler_request_proxy_code(
             const std::string& action, const nlohmann::json& twofactor_data)
             = 0;
-        virtual nlohmann::json reset_twofactor(const std::string& email) = 0;
+        virtual nlohmann::json request_twofactor_reset(const std::string& email) = 0;
         virtual nlohmann::json confirm_twofactor_reset(
             const std::string& email, bool is_dispute, const nlohmann::json& twofactor_data)
             = 0;
+
+        virtual nlohmann::json request_undo_twofactor_reset(const std::string& email) = 0;
+        virtual nlohmann::json confirm_undo_twofactor_reset(
+            const std::string& email, const nlohmann::json& twofactor_data)
+            = 0;
+
         virtual nlohmann::json cancel_twofactor_reset(const nlohmann::json& twofactor_data) = 0;
 
         virtual nlohmann::json set_pin(

--- a/src/swig_java/swig_gasdk.i
+++ b/src/swig_java/swig_gasdk.i
@@ -544,6 +544,7 @@ LOCALFUNC jbyteArray create_array(JNIEnv *jenv, const unsigned char* p, size_t l
 %returns_void__(GA_auth_handler_call)
 %returns_struct(GA_twofactor_cancel_reset, GA_auth_handler)
 %returns_struct(GA_twofactor_reset, GA_auth_handler)
+%returns_struct(GA_twofactor_undo_reset, GA_auth_handler)
 %returns_struct(GA_twofactor_change_limits, GA_auth_handler)
 %returns_struct(GA_change_settings_twofactor, GA_auth_handler)
 %returns_struct(GA_auth_handler_get_status, GA_json)

--- a/src/swig_python/python_extra.py_in
+++ b/src/swig_python/python_extra.py_in
@@ -265,6 +265,9 @@ class Session(object):
     def twofactor_reset(self, email, is_dispute):
         return Call(twofactor_reset(self.session_obj, email, is_dispute))
 
+    def twofactor_undo_reset(self, email):
+        return Call(twofactor_undo_reset(self.session_obj, email))
+
     def twofactor_cancel_reset(self):
         return Call(twofactor_cancel_reset(self.session_obj))
 


### PR DESCRIPTION
Calling undo will return an internal error until the corresponding backend changes are rolled out.