### PR TITLE
Validate generated mnemonics before returning them

### DIFF
--- a/src/ga_wally.cpp
+++ b/src/ga_wally.cpp
@@ -327,6 +327,11 @@ namespace sdk {
     {
         char* s;
         GDK_VERIFY(::bip39_mnemonic_from_bytes(nullptr, data.data(), data.size(), &s));
+        if (::bip39_mnemonic_validate(nullptr, s) != GA_OK) {
+            wally_free_string(s);
+            // This should only be possible with bad hardware/cosmic rays
+            GDK_RUNTIME_ASSERT_MSG(false, "Mnemonic creation failed!");
+        }
         return make_string(s);
     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -555,6 +555,12 @@ template <std::size_t N> int generate_mnemonic(char** output)
         GDK_RUNTIME_ASSERT(output);
         auto entropy = ga::sdk::get_random_bytes<N>();
         GDK_VERIFY(::bip39_mnemonic_from_bytes(nullptr, entropy.data(), entropy.size(), output));
+        if (::bip39_mnemonic_validate(nullptr, *output) != GA_OK) {
+            wally_free_string(*output);
+            *output = nullptr;
+            // This should only be possible with bad hardware/cosmic rays
+            GDK_RUNTIME_ASSERT_MSG(false, "Mnemonic creation failed!");
+        }
         wally_bzero(entropy.data(), entropy.size());
         return GA_OK;
     } catch (const std::exception& e) {


### PR DESCRIPTION
Any invalid generated mnemonic would fail when later used, but its
better to catch such cases (which could indicate hardware flakyness) as
soon as possible.