### PR TITLE
Use wally for base64 conversions

### DIFF
--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -1767,9 +1767,10 @@ namespace sdk {
         GDK_RUNTIME_ASSERT(locker.owns_lock());
 
         const auto saved{ m_blob.save(*m_blob_aes_key, *m_blob_hmac_key) };
-        const auto blob_b64{ base64_from_bytes(saved.first) };
+        auto blob_b64{ base64_string_from_bytes(saved.first) };
 
-        auto result = wamp_call(locker, "login.set_client_blob", blob_b64, 0, saved.second, old_hmac);
+        auto result = wamp_call(locker, "login.set_client_blob", blob_b64.get(), 0, saved.second, old_hmac);
+        blob_b64.reset();
         if (!wamp_cast<bool>(result)) {
             // Raced with another update on the server, caller should try again
             GDK_LOG_SEV(log_level::info) << "Save client blob race, retrying";

--- a/src/ga_wally.cpp
+++ b/src/ga_wally.cpp
@@ -6,14 +6,6 @@
 namespace ga {
 namespace sdk {
 
-    namespace {
-        struct string_dtor {
-            void operator()(char* p) { wally_free_string(p); }
-        };
-        inline std::string make_string(char* p) { return std::string(std::unique_ptr<char, string_dtor>(p).get()); }
-
-    } // namespace
-
     std::array<unsigned char, HASH160_LEN> hash160(byte_span_t data)
     {
         std::array<unsigned char, HASH160_LEN> ret;
@@ -443,6 +435,19 @@ namespace sdk {
         GDK_RUNTIME_ASSERT(written <= ret.size());
         ret.resize(written);
         return ret;
+    }
+
+    wally_string_ptr base64_string_from_bytes(byte_span_t bytes)
+    {
+        char* output = nullptr;
+        GDK_VERIFY(wally_base64_from_bytes(bytes.data(), bytes.size(), 0, &output));
+        return wally_string_ptr(output);
+    }
+
+    std::string base64_from_bytes(byte_span_t bytes)
+    {
+        auto ret = base64_string_from_bytes(bytes);
+        return std::string(ret.get());
     }
 
     std::vector<unsigned char> base64_to_bytes(const std::string& base64)

--- a/src/ga_wally.cpp
+++ b/src/ga_wally.cpp
@@ -445,6 +445,17 @@ namespace sdk {
         return ret;
     }
 
+    std::vector<unsigned char> base64_to_bytes(const std::string& base64)
+    {
+        size_t written;
+        GDK_VERIFY(wally_base64_get_maximum_length(base64.data(), 0, &written));
+        std::vector<unsigned char> ret(written);
+        GDK_VERIFY(wally_base64_to_bytes(base64.data(), 0, &ret[0], ret.size(), &written));
+        GDK_RUNTIME_ASSERT(written <= ret.size());
+        ret.resize(written);
+        return ret;
+    }
+
     //
     // Signing/Encryption
     //

--- a/src/ga_wally.hpp
+++ b/src/ga_wally.hpp
@@ -204,6 +204,8 @@ namespace sdk {
 
     std::vector<unsigned char> base58check_to_bytes(const std::string& base58);
 
+    std::vector<unsigned char> base64_to_bytes(const std::string& base64);
+
     //
     // Signing/Encryption
     //

--- a/src/ga_wally.hpp
+++ b/src/ga_wally.hpp
@@ -61,6 +61,12 @@ namespace sdk {
     using cvalue_t = std::array<unsigned char, WALLY_TX_ASSET_CT_VALUE_UNBLIND_LEN>;
     using blinding_key_t = std::array<unsigned char, HMAC_SHA512_LEN>;
 
+    struct wally_string_dtor {
+        void operator()(char* p) { wally_free_string(p); }
+    };
+    using wally_string_ptr = std::unique_ptr<char, wally_string_dtor>;
+    inline std::string make_string(char* p) { return std::string(wally_string_ptr(p).get()); }
+
 #ifdef __GNUC__
 #define GA_USE_RESULT __attribute__((warn_unused_result))
 #else
@@ -203,6 +209,10 @@ namespace sdk {
     std::string base58check_from_bytes(byte_span_t data);
 
     std::vector<unsigned char> base58check_to_bytes(const std::string& base58);
+
+    wally_string_ptr base64_string_from_bytes(byte_span_t bytes);
+
+    std::string base64_from_bytes(byte_span_t bytes);
 
     std::vector<unsigned char> base64_to_bytes(const std::string& base64);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -430,14 +430,6 @@ namespace sdk {
 
     std::string base64_from_bytes(byte_span_t bytes) { return websocketpp::base64_encode(bytes.data(), bytes.size()); }
 
-    std::vector<unsigned char> base64_to_bytes(const std::string& input)
-    {
-        // FIXME: Use wally to eliminate memory copies here
-        const std::string bytes_string = websocketpp::base64_decode(input);
-        const auto bytes_span = ustring_span(bytes_string);
-        return std::vector<unsigned char>(bytes_span.begin(), bytes_span.end());
-    }
-
     std::vector<unsigned char> compress(byte_span_t prefix, byte_span_t bytes)
     {
         const size_t prefix_len = prefix.size();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -33,7 +33,6 @@
 #if defined _WIN32 || defined WIN32 || defined __CYGWIN__
 #include "bcrypt.h"
 #endif
-#include <websocketpp/base64/base64.hpp>
 
 namespace ga {
 namespace sdk {
@@ -427,8 +426,6 @@ namespace sdk {
             throw user_error(res::id_signature_validation_failed_if);
         }
     }
-
-    std::string base64_from_bytes(byte_span_t bytes) { return websocketpp::base64_encode(bytes.data(), bytes.size()); }
 
     std::vector<unsigned char> compress(byte_span_t prefix, byte_span_t bytes)
     {

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -98,10 +98,6 @@ namespace sdk {
     size_t aes_gcm_encrypt_get_length(byte_span_t plaintext);
     size_t aes_gcm_encrypt(byte_span_t key, byte_span_t plaintext, gsl::span<unsigned char> cyphertext);
 
-    // FIXME: Export base64 encode/decode from wally and use those functions
-    std::string base64_from_bytes(byte_span_t bytes);
-    std::vector<unsigned char> base64_to_bytes(const std::string& input);
-
     // Return prefix followed by compressed `bytes`
     std::vector<unsigned char> compress(byte_span_t prefix, byte_span_t bytes);
     // Return decompressed `bytes` (prefix is assumed removed by the caller)


### PR DESCRIPTION
Wallys implementation allows us to avoid some allocations and copying, useful given the potential size of the client blob.