### PR TITLE
rust: Followup changes for multi-account support (#93)

### DIFF
--- a/src/ga_auth_handlers.cpp
+++ b/src/ga_auth_handlers.cpp
@@ -489,12 +489,14 @@ namespace sdk {
             return;
         }
 
+        const std::string type = details.at("type");
+
         // also check if we need to upload a few confidential addrs
-        if (m_session.is_liquid() && details.at("type") == "2of2_no_recovery") {
+        if (m_session.is_liquid() && type == "2of2_no_recovery") {
             m_remaining_ca_addrs = INITIAL_UPLOAD_CA;
         }
         try {
-            m_subaccount = session.get_next_subaccount();
+            m_subaccount = session.get_next_subaccount(type);
         } catch (const std::exception& e) {
             set_error(e.what());
             return;

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -199,7 +199,11 @@ namespace sdk {
         throw std::runtime_error("remove_account not implemented");
     }
 
-    uint32_t ga_rust::get_next_subaccount() { throw std::runtime_error("get_next_subaccount not implemented"); }
+    uint32_t ga_rust::get_next_subaccount(const std::string& type)
+    {
+        return call_session("get_next_subaccount", nlohmann::json{ { "type", type } });
+    }
+
     nlohmann::json ga_rust::create_subaccount(const nlohmann::json& details, uint32_t subaccount)
     {
         throw std::runtime_error("create_subaccount not implemented");

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -277,7 +277,11 @@ namespace sdk {
 
     void ga_rust::rename_subaccount(uint32_t subaccount, const std::string& new_name)
     {
-        throw std::runtime_error("rename_subaccount not implemented");
+        auto details = nlohmann::json{
+            { "subaccount", subaccount },
+            { "new_name", new_name },
+        };
+        call_session("rename_subaccount", details);
     }
 
     void ga_rust::set_subaccount_hidden(uint32_t subaccount, bool is_hidden)

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -206,12 +206,16 @@ namespace sdk {
 
     nlohmann::json ga_rust::create_subaccount(const nlohmann::json& details, uint32_t subaccount)
     {
-        throw std::runtime_error("create_subaccount not implemented");
+        auto details_c = nlohmann::json{
+            { "subaccount", subaccount },
+            { "name", details.at("name") },
+        };
+        return call_session("create_subaccount", details_c);
     }
     nlohmann::json ga_rust::create_subaccount(
         const nlohmann::json& details, uint32_t subaccount, const std::string& xpub)
     {
-        throw std::runtime_error("create_subaccount not implemented");
+        throw std::runtime_error("create_subaccount with xpub not implemented");
     }
 
     void ga_rust::change_settings_limits(const nlohmann::json& limit_details, const nlohmann::json& twofactor_data)

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -282,7 +282,11 @@ namespace sdk {
 
     void ga_rust::set_subaccount_hidden(uint32_t subaccount, bool is_hidden)
     {
-        throw std::runtime_error("set_subaccount_hidden not implemented");
+        auto details = nlohmann::json{
+            { "subaccount", subaccount },
+            { "hidden", is_hidden },
+        };
+        call_session("set_subaccount_hidden", details);
     }
 
     std::vector<uint32_t> ga_rust::get_subaccount_root_path(uint32_t subaccount)

--- a/src/ga_rust.hpp
+++ b/src/ga_rust.hpp
@@ -87,7 +87,7 @@ namespace sdk {
         std::string get_watch_only_username();
         bool remove_account(const nlohmann::json& twofactor_data);
 
-        uint32_t get_next_subaccount();
+        uint32_t get_next_subaccount(const std::string& type);
         nlohmann::json create_subaccount(const nlohmann::json& details, uint32_t subaccount);
         nlohmann::json create_subaccount(const nlohmann::json& details, uint32_t subaccount, const std::string& xpub);
 

--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -2286,8 +2286,10 @@ namespace sdk {
         return sa;
     }
 
-    uint32_t ga_session::get_next_subaccount()
+    uint32_t ga_session::get_next_subaccount(const std::string& type)
     {
+        // the `type` argument isn't used in ga_session, only in ga_rust
+        (void)type;
         locker_t locker(m_mutex);
         const uint32_t subaccount = m_next_subaccount;
         ++m_next_subaccount;

--- a/src/ga_session.hpp
+++ b/src/ga_session.hpp
@@ -101,7 +101,7 @@ namespace sdk {
         nlohmann::json get_cached_subaccount(uint32_t subaccount) const;
         void rename_subaccount(uint32_t subaccount, const std::string& new_name);
         void set_subaccount_hidden(uint32_t subaccount, bool is_hidden);
-        uint32_t get_next_subaccount();
+        uint32_t get_next_subaccount(const std::string& type);
         nlohmann::json create_subaccount(const nlohmann::json& details, uint32_t subaccount);
         nlohmann::json create_subaccount(const nlohmann::json& details, uint32_t subaccount, const std::string& xpub);
         nlohmann::json get_receive_address(uint32_t subaccount, const std::string& addr_type_);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -430,11 +430,11 @@ namespace sdk {
         });
     }
 
-    uint32_t session::get_next_subaccount()
+    uint32_t session::get_next_subaccount(const std::string& type)
     {
         return exception_wrapper([&] {
             auto p = get_nonnull_impl();
-            return p->get_next_subaccount();
+            return p->get_next_subaccount(type);
         });
     }
 

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -66,7 +66,7 @@ namespace sdk {
         std::string get_watch_only_username();
         bool remove_account(const nlohmann::json& twofactor_data);
 
-        uint32_t get_next_subaccount();
+        uint32_t get_next_subaccount(const std::string& type);
         nlohmann::json create_subaccount(const nlohmann::json& details, uint32_t subaccount);
         nlohmann::json create_subaccount(const nlohmann::json& details, uint32_t subaccount, const std::string& xpub);
         std::vector<uint32_t> get_subaccount_root_path(uint32_t subaccount);

--- a/src/session_common.hpp
+++ b/src/session_common.hpp
@@ -68,7 +68,7 @@ namespace sdk {
         virtual std::string get_watch_only_username() = 0;
         virtual bool remove_account(const nlohmann::json& twofactor_data) = 0;
 
-        virtual uint32_t get_next_subaccount() = 0;
+        virtual uint32_t get_next_subaccount(const std::string& type) = 0;
         virtual nlohmann::json create_subaccount(const nlohmann::json& details, uint32_t subaccount) = 0;
         virtual nlohmann::json create_subaccount(
             const nlohmann::json& details, uint32_t subaccount, const std::string& xpub)

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -148,9 +148,8 @@ pub struct GetAddressOpt {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CreateAccountOpt {
+    pub subaccount: u32,
     pub name: String,
-    #[serde(rename = "type")]
-    pub script_type: ScriptType,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -370,6 +370,12 @@ pub struct UpdateAccountOpt {
     pub hidden: Option<bool>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct SetAccountHiddenOpt {
+    pub subaccount: u32,
+    pub hidden: bool,
+}
+
 /// {"icons":true,"assets":false,"refresh":false}
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RefreshAssets {

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -154,6 +154,12 @@ pub struct CreateAccountOpt {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetNextAccountOpt {
+    #[serde(rename = "type")]
+    pub script_type: ScriptType,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct RenameAccountOpt {
     pub subaccount: u32,
     pub new_name: String,

--- a/subprojects/gdk_rust/gdk_common/src/scripts.rs
+++ b/subprojects/gdk_rust/gdk_common/src/scripts.rs
@@ -7,11 +7,11 @@ use bitcoin::{Address, Network, PublicKey, Script};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ScriptType {
-    #[serde(rename(serialize = "p2sh-p2wpkh"))]
+    #[serde(rename = "p2sh-p2wpkh")]
     P2shP2wpkh = 0,
-    #[serde(rename(serialize = "p2wpkh"))]
+    #[serde(rename = "p2wpkh")]
     P2wpkh = 1,
-    #[serde(rename(serialize = "p2pkh"))]
+    #[serde(rename = "p2pkh")]
     P2pkh = 2,
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -29,6 +29,7 @@ pub trait Session<E> {
     /// Deprecated in favor of update_subaccount
     fn rename_subaccount(&mut self, opt: RenameAccountOpt) -> Result<(), E>;
     fn update_subaccount(&mut self, opt: UpdateAccountOpt) -> Result<(), E>;
+    fn set_subaccount_hidden(&mut self, opt: SetAccountHiddenOpt) -> Result<(), E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
     fn get_balance(&self, subaccount: u32, num_confs: u32) -> Result<Balances, E>;

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -26,6 +26,7 @@ pub trait Session<E> {
     fn get_subaccounts(&self) -> Result<Vec<AccountInfo>, E>;
     fn get_subaccount(&self, index: u32, num_confs: u32) -> Result<AccountInfo, E>;
     fn create_subaccount(&mut self, opt: CreateAccountOpt) -> Result<AccountInfo, E>;
+    fn get_next_subaccount(&self, opt: GetNextAccountOpt) -> Result<u32, E>;
     /// Deprecated in favor of update_subaccount
     fn rename_subaccount(&mut self, opt: RenameAccountOpt) -> Result<(), E>;
     fn update_subaccount(&mut self, opt: UpdateAccountOpt) -> Result<(), E>;

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -554,17 +554,21 @@ pub fn get_last_next_account_nums(
     (last_account, next_account)
 }
 
+pub fn get_account_script_purpose(account_num: u32) -> Result<(ScriptType, u32), Error> {
+    Ok(match account_num % NUM_RESERVED_ACCOUNT_TYPES {
+        0 => (ScriptType::P2shP2wpkh, 49),
+        1 => (ScriptType::P2wpkh, 84),
+        2 => (ScriptType::P2pkh, 44),
+        _ => return Err(Error::InvalidSubaccount(account_num)),
+    })
+}
+
 fn get_account_derivation(
     account_num: u32,
     network_id: NetworkId,
 ) -> Result<(ScriptType, DerivationPath), Error> {
     let coin_type = get_coin_type(network_id);
-    let (script_type, purpose) = match account_num % NUM_RESERVED_ACCOUNT_TYPES {
-        0 => (ScriptType::P2shP2wpkh, 49),
-        1 => (ScriptType::P2wpkh, 84),
-        2 => (ScriptType::P2pkh, 44),
-        _ => return Err(Error::InvalidSubaccount(account_num)),
-    };
+    let (script_type, purpose) = get_account_script_purpose(account_num)?;
     let bip32_account_num = account_num / NUM_RESERVED_ACCOUNT_TYPES;
 
     // BIP44: m / purpose' / coin_type' / account' / change / address_index

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -128,6 +128,12 @@ impl WalletCtx {
         accounts.into_iter().map(|(_, account)| account)
     }
 
+    pub fn get_next_subaccount(&self, script_type: ScriptType) -> u32 {
+        let (_last_account, next_account) =
+            get_last_next_account_nums(self.accounts.keys().copied().collect(), script_type);
+        next_account
+    }
+
     pub fn create_account(&mut self, opt: CreateAccountOpt) -> Result<&Account, Error> {
         // Get the next available account number for the given script type.
         // The script type is later derived from the account number.

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -145,10 +145,6 @@ impl WalletCtx {
         Ok(account)
     }
 
-    pub fn rename_account(&mut self, account_num: u32, new_name: &str) -> Result<(), Error> {
-        self.get_account(account_num)?.set_name(new_name)
-    }
-
     pub fn update_account(&mut self, opt: UpdateAccountOpt) -> Result<(), Error> {
         self.get_account(opt.subaccount)?.set_settings(opt)
     }

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -650,7 +650,19 @@ impl Session<Error> for ElectrumSession {
     }
 
     fn rename_subaccount(&mut self, opt: RenameAccountOpt) -> Result<(), Error> {
-        self.get_wallet_mut()?.rename_account(opt.subaccount, &opt.new_name)
+        self.get_wallet_mut()?.update_account(UpdateAccountOpt {
+            subaccount: opt.subaccount,
+            name: Some(opt.new_name),
+            hidden: None,
+        })
+    }
+
+    fn set_subaccount_hidden(&mut self, opt: SetAccountHiddenOpt) -> Result<(), Error> {
+        self.get_wallet_mut()?.update_account(UpdateAccountOpt {
+            subaccount: opt.subaccount,
+            hidden: Some(opt.hidden),
+            name: None,
+        })
     }
 
     fn update_subaccount(&mut self, opt: UpdateAccountOpt) -> Result<(), Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -649,6 +649,10 @@ impl Session<Error> for ElectrumSession {
         account.info(0)
     }
 
+    fn get_next_subaccount(&self, opt: GetNextAccountOpt) -> Result<u32, Error> {
+        Ok(self.get_wallet()?.get_next_subaccount(opt.script_type))
+    }
+
     fn rename_subaccount(&mut self, opt: RenameAccountOpt) -> Result<(), Error> {
         self.get_wallet_mut()?.update_account(UpdateAccountOpt {
             subaccount: opt.subaccount,

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -23,8 +23,8 @@ use std::sync::Once;
 use std::time::{Duration, SystemTime};
 
 use gdk_common::model::{
-    CreateAccountOpt, GDKRUST_json, GetTransactionsOpt, RenameAccountOpt, SPVVerifyTx,
-    SetAccountHiddenOpt, UpdateAccountOpt,
+    CreateAccountOpt, GDKRUST_json, GetNextAccountOpt, GetTransactionsOpt, RenameAccountOpt,
+    SPVVerifyTx, SetAccountHiddenOpt, UpdateAccountOpt,
 };
 use gdk_common::session::Session;
 
@@ -383,6 +383,13 @@ where
             session
                 .create_subaccount(opt)
                 .map(|x| serialize::subaccount_value(&x))
+                .map_err(Into::into)
+        }
+        "get_next_subaccount" => {
+            let opt: GetNextAccountOpt = serde_json::from_value(input.clone())?;
+            session
+                .get_next_subaccount(opt)
+                .map(|next_subaccount| json!(next_subaccount))
                 .map_err(Into::into)
         }
         "rename_subaccount" => {

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, SystemTime};
 
 use gdk_common::model::{
     CreateAccountOpt, GDKRUST_json, GetTransactionsOpt, RenameAccountOpt, SPVVerifyTx,
-    UpdateAccountOpt,
+    SetAccountHiddenOpt, UpdateAccountOpt,
 };
 use gdk_common::session::Session;
 
@@ -388,6 +388,10 @@ where
         "rename_subaccount" => {
             let opt: RenameAccountOpt = serde_json::from_value(input.clone())?;
             session.rename_subaccount(opt).map(|_| json!(true)).map_err(Into::into)
+        }
+        "set_subaccount_hidden" => {
+            let opt: SetAccountHiddenOpt = serde_json::from_value(input.clone())?;
+            session.set_subaccount_hidden(opt).map(|_| json!(true)).map_err(Into::into)
         }
         "update_subaccount" => {
             let opt: UpdateAccountOpt = serde_json::from_value(input.clone())?;

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -89,7 +89,7 @@ pub fn subaccounts_value(subaccounts: &[AccountInfo]) -> Value {
 pub fn subaccount_value(subaccount: &AccountInfo) -> Value {
     json!({
         "type": subaccount.script_type,
-        "pointer": 0,
+        "pointer": subaccount.account_num,
         "required_ca": 0,
         "receiving_id": "",
         "name": subaccount.settings.name,


### PR DESCRIPTION
Expose the new functionality through the CPP interface, with some adjustments to match the `ga_auth_handlers` flow.