### PR TITLE
 rust: spend unconfidential utxos

### DIFF
--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -62,6 +62,10 @@ impl Unblinded {
     pub fn asset_hex(&self) -> String {
         asset_to_hex(&self.asset)
     }
+
+    pub fn confidential(&self) -> bool {
+        self.abf != [0u8; 32] || self.vbf != [0u8; 32]
+    }
 }
 
 impl Debug for Unblinded {

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -123,6 +123,7 @@ pub struct CreateTransaction {
     pub utxos: Option<GetUnspentOutputs>,
     /// Minimum number of confirmations for coin selection
     pub num_confs: Option<u32>,
+    pub confidential_utxos_only: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -137,12 +138,14 @@ pub struct GetTransactionsOpt {
 pub struct GetBalanceOpt {
     pub subaccount: u32,
     pub num_confs: u32,
+    pub confidential: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GetUnspentOpt {
     pub subaccount: u32,
     pub num_confs: Option<u32>,
+    pub confidential: Option<bool>,
     pub all_coins: Option<usize>, // unused
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -134,6 +134,12 @@ pub struct GetTransactionsOpt {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct GetBalanceOpt {
+    pub subaccount: u32,
+    pub num_confs: u32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GetUnspentOpt {
     pub subaccount: u32,
     pub num_confs: Option<u32>,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -138,14 +138,16 @@ pub struct GetTransactionsOpt {
 pub struct GetBalanceOpt {
     pub subaccount: u32,
     pub num_confs: u32,
-    pub confidential: Option<bool>,
+    #[serde(rename = "confidential")]
+    pub confidential_utxos_only: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct GetUnspentOpt {
     pub subaccount: u32,
     pub num_confs: Option<u32>,
-    pub confidential: Option<bool>,
+    #[serde(rename = "confidential")]
+    pub confidential_utxos_only: Option<bool>,
     pub all_coins: Option<usize>, // unused
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -33,7 +33,7 @@ pub trait Session<E> {
     fn set_subaccount_hidden(&mut self, opt: SetAccountHiddenOpt) -> Result<(), E>;
     fn get_transactions(&self, opt: &GetTransactionsOpt) -> Result<TxsResult, E>;
     fn get_transaction_details(&self, txid: &str) -> Result<Value, E>;
-    fn get_balance(&self, subaccount: u32, num_confs: u32) -> Result<Balances, E>;
+    fn get_balance(&self, opt: &GetBalanceOpt) -> Result<Balances, E>;
     fn set_transaction_memo(&self, txid: &str, memo: &str) -> Result<(), E>;
     fn create_transaction(&mut self, details: &mut CreateTransaction)
         -> Result<TransactionMeta, E>;

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -261,7 +261,7 @@ impl Account {
         Ok(txs)
     }
 
-    pub fn utxos(&self, num_confs: u32, confidential: bool) -> Result<Utxos, Error> {
+    pub fn utxos(&self, num_confs: u32, confidential_utxos_only: bool) -> Result<Utxos, Error> {
         info!("start utxos");
         let store_read = self.store.read()?;
         let acc_store = store_read.account_cache(self.account_num)?;
@@ -331,7 +331,7 @@ impl Account {
                                     {
                                         return None;
                                     }
-                                    if confidential && !unblinded.confidential() {
+                                    if confidential_utxos_only && !unblinded.confidential() {
                                         return None;
                                     }
                                     return Some((
@@ -376,7 +376,11 @@ impl Account {
         Ok(result)
     }
 
-    pub fn balance(&self, num_confs: u32, confidential: bool) -> Result<Balances, Error> {
+    pub fn balance(
+        &self,
+        num_confs: u32,
+        confidential_utxos_only: bool,
+    ) -> Result<Balances, Error> {
         info!("start balance");
         let mut result = HashMap::new();
         match self.network.id() {
@@ -385,7 +389,7 @@ impl Account {
                 result.entry(self.network.policy_asset.as_ref().unwrap().clone()).or_insert(0)
             }
         };
-        for (_, info) in self.utxos(num_confs, confidential)?.iter() {
+        for (_, info) in self.utxos(num_confs, confidential_utxos_only)?.iter() {
             *result.entry(info.asset.clone()).or_default() += info.value as i64;
         }
         Ok(result)

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use gdk_common::mnemonic::Mnemonic;
 use gdk_common::model::{
-    AddressPointer, Balances, CreateAccountOpt, CreateTransaction, GetTransactionsOpt,
-    GetUnspentOpt, Settings, TransactionMeta, UpdateAccountOpt,
+    AddressPointer, Balances, CreateAccountOpt, CreateTransaction, GetBalanceOpt,
+    GetTransactionsOpt, GetUnspentOpt, Settings, TransactionMeta, UpdateAccountOpt,
 };
 use gdk_common::network::Network;
 use gdk_common::scripts::ScriptType;
@@ -211,8 +211,8 @@ impl WalletCtx {
         self.get_account(opt.subaccount)?.utxos(opt.num_confs.unwrap_or(0))
     }
 
-    pub fn balance(&self, account_num: u32, num_confs: u32) -> Result<Balances, Error> {
-        self.get_account(account_num)?.balance(num_confs)
+    pub fn balance(&self, opt: &GetBalanceOpt) -> Result<Balances, Error> {
+        self.get_account(opt.subaccount)?.balance(opt.num_confs)
     }
 
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -208,11 +208,12 @@ impl WalletCtx {
 
     pub fn utxos(&self, opt: &GetUnspentOpt) -> Result<Utxos, Error> {
         // TODO does not support the `all_coins` option
-        self.get_account(opt.subaccount)?.utxos(opt.num_confs.unwrap_or(0))
+        self.get_account(opt.subaccount)?
+            .utxos(opt.num_confs.unwrap_or(0), opt.confidential.unwrap_or(false))
     }
 
     pub fn balance(&self, opt: &GetBalanceOpt) -> Result<Balances, Error> {
-        self.get_account(opt.subaccount)?.balance(opt.num_confs)
+        self.get_account(opt.subaccount)?.balance(opt.num_confs, opt.confidential.unwrap_or(false))
     }
 
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/interface.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/interface.rs
@@ -209,11 +209,12 @@ impl WalletCtx {
     pub fn utxos(&self, opt: &GetUnspentOpt) -> Result<Utxos, Error> {
         // TODO does not support the `all_coins` option
         self.get_account(opt.subaccount)?
-            .utxos(opt.num_confs.unwrap_or(0), opt.confidential.unwrap_or(false))
+            .utxos(opt.num_confs.unwrap_or(0), opt.confidential_utxos_only.unwrap_or(false))
     }
 
     pub fn balance(&self, opt: &GetBalanceOpt) -> Result<Balances, Error> {
-        self.get_account(opt.subaccount)?.balance(opt.num_confs, opt.confidential.unwrap_or(false))
+        self.get_account(opt.subaccount)?
+            .balance(opt.num_confs, opt.confidential_utxos_only.unwrap_or(false))
     }
 
     pub fn create_tx(&self, request: &mut CreateTransaction) -> Result<TransactionMeta, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -1380,7 +1380,16 @@ impl Syncer {
                 };
                 Ok(unblinded)
             }
-            _ => Err(Error::Generic("received unconfidential or null asset/value/nonce".into())),
+            (Asset::Explicit(asset_id), confidential::Value::Explicit(satoshi), _) => {
+                let unblinded = Unblinded {
+                    asset: asset_id.into_inner().into_inner(),
+                    value: satoshi,
+                    abf: [0u8; 32],
+                    vbf: [0u8; 32],
+                };
+                Ok(unblinded)
+            }
+            _ => Err(Error::Generic("Unexpected asset/value/nonce".into())),
         }
     }
 }

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -683,8 +683,8 @@ impl Session<Error> for ElectrumSession {
         Err(Error::Generic("implementme: ElectrumSession get_transaction_details".into()))
     }
 
-    fn get_balance(&self, account_num: u32, num_confs: u32) -> Result<Balances, Error> {
-        self.get_wallet()?.balance(account_num, num_confs)
+    fn get_balance(&self, opt: &GetBalanceOpt) -> Result<Balances, Error> {
+        self.get_wallet()?.balance(opt)
     }
 
     fn set_transaction_memo(&self, txid: &str, memo: &str) -> Result<(), Error> {

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -411,7 +411,10 @@ where
         }
 
         "get_transaction_details" => get_transaction_details(session, input),
-        "get_balance" => serialize::get_balance(session, input),
+        "get_balance" => session
+            .get_unspent_outputs(&serde_json::from_value(input.clone())?)
+            .map(|v| json!(v))
+            .map_err(Into::into),
         "set_transaction_memo" => set_transaction_memo(session, input),
         "create_transaction" => serialize::create_transaction(session, input),
         "sign_transaction" => session

--- a/subprojects/gdk_rust/src/serialize.rs
+++ b/subprojects/gdk_rust/src/serialize.rs
@@ -215,23 +215,6 @@ where
     session.set_transaction_memo(txid, memo).map(|v| json!(v)).map_err(Into::into)
 }
 
-pub fn get_balance<S, E>(session: &S, input: &Value) -> Result<Value, Error>
-where
-    E: Into<Error>,
-    S: Session<E>,
-{
-    let num_confs = input["num_confs"].as_u64().unwrap_or(0);
-
-    let subaccount = input["subaccount"]
-        .as_u64()
-        .ok_or_else(|| Error::Other("get_balance: missing subaccount".into()))?
-        as u32;
-
-    let bal = session.get_balance(subaccount, num_confs as u32).map_err(Into::into)?;
-
-    Ok(balance_result_value(&bal))
-}
-
 pub fn fee_estimate_values(estimates: &[FeeEstimate]) -> Result<Value, Error> {
     if estimates.is_empty() {
         // Current apps depend on this length

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -902,6 +902,7 @@ impl TestSession {
         let opt = GetBalanceOpt {
             subaccount: 0,
             num_confs: 0,
+            confidential: None,
         };
         self.session.get_balance(&opt).unwrap()
     }
@@ -915,6 +916,7 @@ impl TestSession {
         let opt = GetBalanceOpt {
             subaccount: account_num,
             num_confs: 0,
+            confidential: None,
         };
         let balance = self.session.get_balance(&opt).unwrap();
         match self.network_id {
@@ -979,6 +981,7 @@ impl TestSession {
         let utxo_opt = GetUnspentOpt {
             subaccount: 0,
             num_confs: None,
+            confidential: None,
             all_coins: None,
         };
         let outputs = self.session.get_unspent_outputs(&utxo_opt).unwrap();

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -899,7 +899,11 @@ impl TestSession {
 
     /// balance in satoshi (or liquid satoshi) of the gdk session for account 0
     fn balance_gdk_all(&self) -> Balances {
-        self.session.get_balance(0, 0).unwrap()
+        let opt = GetBalanceOpt {
+            subaccount: 0,
+            num_confs: 0,
+        };
+        self.session.get_balance(&opt).unwrap()
     }
 
     /// balance in satoshi (or liquid satoshi) of the gdk session for account 0
@@ -908,7 +912,11 @@ impl TestSession {
     }
 
     pub fn balance_account(&self, account_num: u32, asset: Option<String>) -> u64 {
-        let balance = self.session.get_balance(account_num, 0).unwrap();
+        let opt = GetBalanceOpt {
+            subaccount: account_num,
+            num_confs: 0,
+        };
+        let balance = self.session.get_balance(&opt).unwrap();
         match self.network_id {
             NetworkId::Elements(_) => {
                 let asset =

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -390,7 +390,7 @@ impl TestSession {
         asset: Option<String>,
         memo: Option<String>,
         unspent_outputs: Option<GetUnspentOutputs>,
-        confidential: Option<bool>,
+        confidential_utxos_only: Option<bool>,
     ) -> String {
         let init_sat = self.balance_gdk(asset.clone());
         let init_node_balance = self.balance_node(asset.clone());
@@ -407,7 +407,7 @@ impl TestSession {
         });
         create_opt.memo = memo;
         create_opt.utxos = unspent_outputs;
-        create_opt.confidential_utxos_only = confidential;
+        create_opt.confidential_utxos_only = confidential_utxos_only;
         let tx = self.session.create_transaction(&mut create_opt).unwrap();
         assert!(tx.user_signed, "tx is not marked as user_signed");
         match self.network.id() {
@@ -614,7 +614,7 @@ impl TestSession {
         self.wait_tx_status_change();
         // confidential balance
         assert_eq!(init_sat, self.balance_account(0, None, Some(true)));
-        utxos_opt.confidential = Some(true);
+        utxos_opt.confidential_utxos_only = Some(true);
         assert_eq!(
             init_num_utxos,
             self.session
@@ -627,7 +627,7 @@ impl TestSession {
         );
         // confidential and unconfidential balance (default)
         assert_eq!(init_sat + unconf_sat, self.balance_account(0, None, Some(false)));
-        utxos_opt.confidential = Some(false);
+        utxos_opt.confidential_utxos_only = Some(false);
         assert_eq!(
             init_num_utxos + 1,
             self.session
@@ -671,7 +671,7 @@ impl TestSession {
         // reduces complexity.
         let node_address = self.node_getnewaddress(None);
         let balance_node_before = self.balance_node(None);
-        utxos_opt.confidential = Some(false);
+        utxos_opt.confidential_utxos_only = Some(false);
         let mut utxos = self.session.get_unspent_outputs(&utxos_opt).unwrap();
         utxos.0.get_mut(policy_asset).unwrap().retain(|e| e.txhash == unconf_txid);
         assert_eq!(utxos.0.get(policy_asset).unwrap().len(), 1);
@@ -981,7 +981,7 @@ impl TestSession {
         let opt = GetBalanceOpt {
             subaccount: 0,
             num_confs: 0,
-            confidential: None,
+            confidential_utxos_only: None,
         };
         self.session.get_balance(&opt).unwrap()
     }
@@ -995,12 +995,12 @@ impl TestSession {
         &self,
         account_num: u32,
         asset: Option<String>,
-        confidential: Option<bool>,
+        confidential_utxos_only: Option<bool>,
     ) -> u64 {
         let opt = GetBalanceOpt {
             subaccount: account_num,
             num_confs: 0,
-            confidential,
+            confidential_utxos_only,
         };
         let balance = self.session.get_balance(&opt).unwrap();
         match self.network_id {
@@ -1065,7 +1065,7 @@ impl TestSession {
         let utxo_opt = GetUnspentOpt {
             subaccount: 0,
             num_confs: None,
-            confidential: None,
+            confidential_utxos_only: None,
             all_coins: None,
         };
         let outputs = self.session.get_unspent_outputs(&utxo_opt).unwrap();


### PR DESCRIPTION
Before this change unconfidential (unblinded) outputs were ignored
by the wallet. Now such outputs contribute to the balance and will
be spent by default.

Consistently with the ga_session.cpp implementation, callers who
only want the balance from confidential utxos only or do not want
to spend unblinded utxos, should set "confidential" or
"confidential_utxos_only" to true.
