### PR TITLE
Support greedy addressees

### DIFF
--- a/src/ga_tx.cpp
+++ b/src/ga_tx.cpp
@@ -716,11 +716,7 @@ namespace sdk {
                             // so compute what we can send (everything minus the
                             // fee) and exit the loop
                             required_total = available_total - fee;
-                            if (is_liquid) {
-                                set_tx_output_commitment(tx, 0, asset_id, required_total.value());
-                            } else {
-                                tx->outputs[0].satoshi = required_total.value();
-                            }
+                            set_tx_output_value(net_params, tx, 0, asset_id, required_total.value());
                             if (num_addressees == 1u) {
                                 addressees_p->at(0)["satoshi"] = required_total.value();
                             }

--- a/src/transaction_utils.cpp
+++ b/src/transaction_utils.cpp
@@ -424,7 +424,10 @@ namespace sdk {
 
         // Transactions with outputs below the dust threshold (except OP_RETURN)
         // are not relayed by network nodes
-        if (!result.value("send_all", false) && satoshi.value() < session.get_dust_threshold()) {
+        // This check only applies when the amount has been set explicitly, so send all
+        // and greedy outputs are ignored as the amount is calculated later
+        if (!result.value("send_all", false) && !addressee.value("is_greedy", false)
+            && satoshi.value() < session.get_dust_threshold()) {
             set_tx_error(result, res::id_invalid_amount);
         }
 

--- a/src/transaction_utils.cpp
+++ b/src/transaction_utils.cpp
@@ -435,6 +435,16 @@ namespace sdk {
             asset_id_from_json(net_params, addressee));
     }
 
+    void set_tx_output_value(const network_parameters& net_params, wally_tx_ptr& tx, uint32_t index,
+        const std::string& asset_id, amount::value_type satoshi)
+    {
+        if (net_params.is_liquid()) {
+            set_tx_output_commitment(tx, index, asset_id, satoshi);
+        } else {
+            tx->outputs[index].satoshi = satoshi;
+        }
+    }
+
     void update_tx_size_info(const network_parameters& net_params, const wally_tx_ptr& tx, nlohmann::json& result)
     {
         const bool valid = tx->num_inputs != 0u && tx->num_outputs != 0u;

--- a/src/transaction_utils.hpp
+++ b/src/transaction_utils.hpp
@@ -92,6 +92,9 @@ namespace sdk {
     amount add_tx_addressee(ga_session& session, const network_parameters& net_params, nlohmann::json& result,
         wally_tx_ptr& tx, nlohmann::json& addressee);
 
+    void set_tx_output_value(const network_parameters& net_params, wally_tx_ptr& tx, uint32_t index,
+        const std::string& asset_id, amount::value_type satoshi);
+
     vbf_t generate_final_vbf(byte_span_t input_abfs, byte_span_t input_vbfs, uint64_span_t input_values,
         const std::vector<abf_t>& output_abfs, const std::vector<vbf_t>& output_vbfs, uint32_t num_inputs);
 


### PR DESCRIPTION
Setting the 'greedy' flag on an addressee means it will consume any change instead of it going to a change output.