### PR TITLE
Patch tor configure to fix building with autoconf@2.70

### DIFF
--- a/tools/buildtor.sh
+++ b/tools/buildtor.sh
@@ -67,6 +67,7 @@ else
     $SED -i "741s!^TOR_LIB.*!  TOR_LIB_PTHREAD=-lpthread!" configure.ac
     $SED -i "764a AC_SUBST(TOR_LIB_PTHREAD)" configure.ac
     $SED -i "912s!^TOR_SEARCH.*!TOR_SEARCH_LIBRARY(openssl, \$tryssldir, \[-lssl -lcrypto \$TOR_LIB_GDI \$TOR_LIB_WS32 \$TOR_LIB_CRYPT32\ -ldl \$TOR_LIB_PTHREAD\],!" configure.ac
+    sed -ie "s!^AC_PROG_CC_C99!!" configure.ac
     sh autogen.sh
     ./configure ${CONFIGURE_ARGS} --host=${HOST_OS}
     sed -ie "s!^include src/app.*!!" "src/include.am"


### PR DESCRIPTION
The upstream fix is https://github.com/torproject/tor/commit/02816d60591a6b3887f47df81fb99cb72d5ad2db but requires updating tor to 0.4.5.8.