### PR TITLE
rust: elements: fix p2wpkh, p2pkh address generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -196,7 +196,8 @@ test_rust:
     - cd subprojects/gdk_rust
     - DEBUG=1 ./launch_integration_tests.sh bitcoin
     - DEBUG=1 ./launch_integration_tests.sh liquid
-    - DEBUG=1 ./launch_integration_tests.sh subaccounts
+    - DEBUG=1 ./launch_integration_tests.sh subaccounts_bitcoin
+    - DEBUG=1 ./launch_integration_tests.sh subaccounts_liquid
     - DEBUG=1 ./launch_integration_tests.sh labels
     - DEBUG=1 ./launch_integration_tests.sh rbf
     - DEBUG=1 ./launch_integration_tests.sh spv_cross_validate

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -373,7 +373,7 @@ impl TestSession {
         create_opt.addressees.push(AddressAmount {
             address: address.to_string(),
             satoshi: 0,
-            asset_id: asset_id.clone(),
+            asset_id: asset_id.clone().or(self.asset_id()),
         });
         create_opt.send_all = Some(true);
         let tx = self.session.create_transaction(&mut create_opt).unwrap();


### PR DESCRIPTION
Before this change, we were always using the p2shwpkh script to
derive the blinding public key from the master blinding key. As
a result the address generated had an unexpected blinding public
key, which later caused an unblinding failure and made the fund
unspendable.

Funds are not definitively lost as the blinding key was still
deterministic, but it's not trivial to recover them. Anyway, this
never went live on a production app.