### PR TITLE
rust: tests: rename so they can be run separately

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,8 +194,8 @@ test_rust:
     - curl -L https://github.com/ElementsProject/elements/releases/download/elements-0.18.1.8/elements-0.18.1.8-x86_64-linux-gnu.tar.gz | tar -xvz elements-0.18.1.8/bin/elementsd
     - export ELEMENTSD_EXEC=$PWD/elements-0.18.1.8/bin/elementsd
     - cd subprojects/gdk_rust
-    - DEBUG=1 ./launch_integration_tests.sh bitcoin
-    - DEBUG=1 ./launch_integration_tests.sh liquid
+    - DEBUG=1 ./launch_integration_tests.sh roundtrip_bitcoin
+    - DEBUG=1 ./launch_integration_tests.sh roundtrip_liquid
     - DEBUG=1 ./launch_integration_tests.sh subaccounts_bitcoin
     - DEBUG=1 ./launch_integration_tests.sh subaccounts_liquid
     - DEBUG=1 ./launch_integration_tests.sh labels

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -24,7 +24,7 @@ static MEMO1: &str = "hello memo";
 static MEMO2: &str = "hello memo2";
 
 #[test]
-fn bitcoin() {
+fn roundtrip_bitcoin() {
     let mut test_session = setup_session(false, 0, |_| ());
 
     let node_address = test_session.node_getnewaddress(Some("p2sh-segwit"));
@@ -64,7 +64,7 @@ fn bitcoin() {
 }
 
 #[test]
-fn liquid() {
+fn roundtrip_liquid() {
     let mut test_session = setup_session(true, 0, |_| ());
 
     let node_address = test_session.node_getnewaddress(Some("p2sh-segwit"));


### PR DESCRIPTION
This also fixes flaky test failures.