### PR TITLE
rust: asset_id internal refactoring

### DIFF
--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -58,6 +58,10 @@ pub struct Unblinded {
 }
 
 impl Unblinded {
+    pub fn asset(&self) -> elements::issuance::AssetId {
+        elements::issuance::AssetId::from_slice(&self.asset).unwrap()
+    }
+
     pub fn asset_hex(&self) -> String {
         asset_to_hex(&self.asset)
     }

--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -9,7 +9,7 @@ mod transaction;
 mod txid;
 
 pub use address::*;
-use bitcoin::hashes::hex::ToHex;
+use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::util::bip32::DerivationPath;
 pub use blockhash::*;
 pub use blockheader::*;
@@ -61,6 +61,10 @@ impl UTXOInfo {
             height,
             path,
         }
+    }
+
+    pub fn asset_id(&self) -> Option<elements::issuance::AssetId> {
+        elements::issuance::AssetId::from_hex(&self.asset).ok()
     }
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -64,7 +64,11 @@ impl UTXOInfo {
     }
 
     pub fn asset_id(&self) -> Option<elements::issuance::AssetId> {
-        self.asset.parse().ok()
+        if self.asset == "btc" {
+            None
+        } else {
+            Some(self.asset.parse().expect("Invalid asset"))
+        }
     }
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -32,15 +32,30 @@ pub struct UTXOInfo {
 }
 
 impl UTXOInfo {
-    pub fn new(
-        asset: String,
+    pub fn new_bitcoin(
         value: u64,
         script: BEScript,
         height: Option<u32>,
         path: DerivationPath,
     ) -> Self {
         UTXOInfo {
-            asset,
+            asset: "btc".to_string(),
+            value,
+            script,
+            height,
+            path,
+        }
+    }
+
+    pub fn new_elements(
+        asset: elements::issuance::AssetId,
+        value: u64,
+        script: BEScript,
+        height: Option<u32>,
+        path: DerivationPath,
+    ) -> Self {
+        UTXOInfo {
+            asset: asset.to_hex(),
             value,
             script,
             height,

--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -9,7 +9,7 @@ mod transaction;
 mod txid;
 
 pub use address::*;
-use bitcoin::hashes::hex::{FromHex, ToHex};
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::util::bip32::DerivationPath;
 pub use blockhash::*;
 pub use blockheader::*;
@@ -64,7 +64,7 @@ impl UTXOInfo {
     }
 
     pub fn asset_id(&self) -> Option<elements::issuance::AssetId> {
-        elements::issuance::AssetId::from_hex(&self.asset).ok()
+        self.asset.parse().ok()
     }
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -9,6 +9,7 @@ mod transaction;
 mod txid;
 
 pub use address::*;
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::util::bip32::DerivationPath;
 pub use blockhash::*;
 pub use blockheader::*;
@@ -62,10 +63,6 @@ impl Unblinded {
         elements::issuance::AssetId::from_slice(&self.asset).unwrap()
     }
 
-    pub fn asset_hex(&self) -> String {
-        asset_to_hex(&self.asset)
-    }
-
     pub fn confidential(&self) -> bool {
         self.abf != [0u8; 32] || self.vbf != [0u8; 32]
     }
@@ -73,7 +70,7 @@ impl Unblinded {
 
 impl Debug for Unblinded {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {}", self.asset_hex(), self.value)
+        write!(f, "{} {}", self.asset().to_hex(), self.value)
     }
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/be/mod.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/mod.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 pub use transaction::*;
 pub use txid::*;
 
-pub type AssetId = [u8; 32]; // TODO use elements::issuance::AssetId
 pub type Utxos = Vec<(BEOutPoint, UTXOInfo)>;
 
 #[derive(Debug)]
@@ -52,7 +51,7 @@ impl UTXOInfo {
 
 #[derive(Serialize, Deserialize)]
 pub struct Unblinded {
-    pub asset: AssetId,
+    pub asset: elements::issuance::AssetId,
     pub abf: [u8; 32],
     pub vbf: [u8; 32],
     pub value: u64,
@@ -60,7 +59,7 @@ pub struct Unblinded {
 
 impl Unblinded {
     pub fn asset(&self) -> elements::issuance::AssetId {
-        elements::issuance::AssetId::from_slice(&self.asset).unwrap()
+        self.asset.clone()
     }
 
     pub fn confidential(&self) -> bool {
@@ -70,37 +69,12 @@ impl Unblinded {
 
 impl Debug for Unblinded {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {}", self.asset().to_hex(), self.value)
+        write!(f, "{} {}", self.asset.to_hex(), self.value)
     }
-}
-
-pub fn asset_to_bin(asset: &str) -> Result<AssetId, crate::error::Error> {
-    let mut bytes = hex::decode(asset)?;
-    bytes.reverse();
-    let asset: AssetId = (&bytes[..]).try_into()?;
-    Ok(asset)
-}
-
-pub fn asset_to_hex(asset: &[u8]) -> String {
-    let mut asset = asset.to_vec();
-    asset.reverse();
-    hex::encode(asset)
 }
 
 #[derive(Default)]
 pub struct ScriptBatch {
     pub cached: bool,
     pub value: Vec<(BEScript, DerivationPath)>,
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::be::{asset_to_bin, asset_to_hex};
-
-    #[test]
-    fn test_asset_roundtrip() {
-        let expected = "5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225";
-        let result = asset_to_hex(&asset_to_bin(expected).unwrap());
-        assert_eq!(expected, &result);
-    }
 }

--- a/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
@@ -695,7 +695,7 @@ impl BETransaction {
                             outpoint,
                             unblinded.value
                         );
-                        let asset_id_str = unblinded.asset_hex();
+                        let asset_id_str = unblinded.asset().to_hex();
                         *result.entry(asset_id_str).or_default() -= unblinded.value as i64;
                         // TODO check overflow
                     }
@@ -712,7 +712,7 @@ impl BETransaction {
                             outpoint,
                             unblinded.value
                         );
-                        let asset_id_str = unblinded.asset_hex();
+                        let asset_id_str = unblinded.asset().to_hex();
                         *result.entry(asset_id_str).or_default() += unblinded.value as i64;
                         // TODO check overflow
                     }

--- a/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
@@ -511,13 +511,13 @@ impl BETransaction {
     pub fn add_fee_if_elements(
         &mut self,
         value: u64,
-        policy_asset: &Option<Asset>,
+        policy_asset: &Option<elements::issuance::AssetId>,
     ) -> Result<(), Error> {
         if let BETransaction::Elements(tx) = self {
             let policy_asset =
                 policy_asset.ok_or_else(|| Error::Generic("Missing policy asset".into()))?;
             let new_out = elements::TxOut {
-                asset: policy_asset,
+                asset: confidential::Asset::Explicit(policy_asset),
                 value: confidential::Value::Explicit(value),
                 ..Default::default()
             };
@@ -563,7 +563,7 @@ impl BETransaction {
         &self,
         all_txs: &BETransactions,
         all_unblinded: &HashMap<elements::OutPoint, Unblinded>,
-        policy_asset: &Option<Asset>,
+        policy_asset: &Option<elements::issuance::AssetId>,
     ) -> Result<u64, Error> {
         Ok(match self {
             Self::Bitcoin(tx) => {
@@ -575,8 +575,10 @@ impl BETransaction {
                 let has_fee = tx.output.iter().any(|o| o.is_fee());
 
                 if has_fee {
-                    let policy_asset = policy_asset
-                        .ok_or_else(|| Error::Generic("Missing policy asset".into()))?;
+                    let policy_asset = elements::confidential::Asset::Explicit(
+                        policy_asset
+                            .ok_or_else(|| Error::Generic("Missing policy asset".into()))?,
+                    );
                     tx.output
                         .iter()
                         .filter(|o| o.is_fee())

--- a/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
@@ -362,7 +362,7 @@ impl BETransaction {
         &self,
         fee_rate: f64,
         no_change: bool,
-        policy_asset: Option<String>,
+        policy_asset: Option<elements::issuance::AssetId>,
         all_txs: &BETransactions,
         unblinded: &HashMap<elements::OutPoint, Unblinded>,
         script_type: ScriptType,
@@ -415,7 +415,7 @@ impl BETransaction {
                     self.estimated_changes(no_change, all_txs, unblinded),
                     script_type,
                 );
-                *outputs.entry(policy_asset.clone()).or_insert(0) += estimated_fee;
+                *outputs.entry(policy_asset.to_hex()).or_insert(0) += estimated_fee;
 
                 let mut result = vec![];
                 for (asset, value) in outputs.iter() {
@@ -426,7 +426,7 @@ impl BETransaction {
                     }
                 }
 
-                if let Some(index) = result.iter().position(|e| e.asset == policy_asset) {
+                if let Some(index) = result.iter().position(|e| e.asset == policy_asset.to_hex()) {
                     let last_index = result.len() - 1;
                     if index != last_index {
                         result.swap(index, last_index); // put the policy asset last
@@ -442,7 +442,7 @@ impl BETransaction {
     pub fn changes(
         &self,
         estimated_fee: u64,
-        policy_asset: Option<String>,
+        policy_asset: Option<elements::issuance::AssetId>,
         all_txs: &BETransactions,
         unblinded: &HashMap<elements::OutPoint, Unblinded>,
     ) -> Vec<AssetValue> {
@@ -485,7 +485,7 @@ impl BETransaction {
                 let mut result = vec![];
                 for (asset, value) in inputs_asset_amounts.iter() {
                     let mut sum = value - outputs_asset_amounts.remove(asset).unwrap_or(0);
-                    if asset == policy_asset.as_ref().unwrap() {
+                    if asset == &policy_asset.unwrap().to_hex() {
                         // from a purely privacy perspective could make sense to always create the change output in liquid, so min change = 0
                         // however elements core use the dust anyway for 2 reasons: rebasing from core and economical considerations
                         sum -= estimated_fee;

--- a/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
@@ -8,7 +8,7 @@ use crate::{ElementsNetwork, NetworkId};
 use bitcoin::blockdata::script::Instruction;
 use bitcoin::consensus::encode::deserialize as btc_des;
 use bitcoin::consensus::encode::serialize as btc_ser;
-use bitcoin::hashes::hex::{FromHex, ToHex};
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{self, Message, Secp256k1, Signature};
 use bitcoin::util::bip143::SigHashCache;
@@ -211,7 +211,7 @@ impl BETransaction {
         &mut self,
         address: &str,
         value: u64,
-        asset_hex: Option<String>,
+        asset: Option<elements::issuance::AssetId>,
     ) -> Result<(), Error> {
         match self {
             BETransaction::Bitcoin(tx) => {
@@ -228,9 +228,8 @@ impl BETransaction {
                 let blinding_pubkey = address.blinding_pubkey.ok_or(Error::InvalidAddress)?;
                 let bytes = blinding_pubkey.serialize();
                 let byte32: [u8; 32] = bytes[1..].as_ref().try_into().unwrap();
-                let asset =
-                    asset_hex.expect("add_output must be called with a non empty asset in liquid");
-                let asset_id = elements::issuance::AssetId::from_hex(&asset)?;
+                let asset_id =
+                    asset.expect("add_output must be called with a non empty asset in liquid");
                 let new_out = elements::TxOut {
                     asset: confidential::Asset::Explicit(asset_id),
                     value: confidential::Value::Explicit(value),

--- a/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
@@ -341,11 +341,10 @@ impl BETransaction {
             Self::Elements(tx) => {
                 let mut different_assets = HashSet::new();
                 for input in tx.input.iter() {
-                    let asset_hex = all_txs
+                    let asset = all_txs
                         .get_previous_output_asset(input.previous_output, unblinded)
-                        .unwrap()
-                        .to_hex();
-                    different_assets.insert(asset_hex.clone());
+                        .unwrap();
+                    different_assets.insert(asset);
                 }
                 if different_assets.is_empty() {
                     0

--- a/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
@@ -8,7 +8,7 @@ use crate::{ElementsNetwork, NetworkId};
 use bitcoin::blockdata::script::Instruction;
 use bitcoin::consensus::encode::deserialize as btc_des;
 use bitcoin::consensus::encode::serialize as btc_ser;
-use bitcoin::hashes::hex::ToHex;
+use bitcoin::hashes::hex::{FromHex, ToHex};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{self, Message, Secp256k1, Signature};
 use bitcoin::util::bip143::SigHashCache;
@@ -16,7 +16,7 @@ use bitcoin::{PublicKey, SigHashType};
 use elements::confidential::{Asset, Value};
 use elements::encode::deserialize as elm_des;
 use elements::encode::serialize as elm_ser;
-use elements::{confidential, issuance, AddressParams};
+use elements::{confidential, AddressParams};
 use elements::{TxInWitness, TxOutWitness};
 use log::{info, trace};
 use rand::seq::SliceRandom;
@@ -230,8 +230,7 @@ impl BETransaction {
                 let byte32: [u8; 32] = bytes[1..].as_ref().try_into().unwrap();
                 let asset =
                     asset_hex.expect("add_output must be called with a non empty asset in liquid");
-                let asset = asset_to_bin(&asset).expect("invalid asset hex");
-                let asset_id = issuance::AssetId::from_slice(&asset)?;
+                let asset_id = elements::issuance::AssetId::from_hex(&asset)?;
                 let new_out = elements::TxOut {
                     asset: confidential::Asset::Explicit(asset_id),
                     value: confidential::Value::Explicit(value),
@@ -391,8 +390,7 @@ impl BETransaction {
                 for output in tx.output.iter() {
                     match (output.asset, output.value) {
                         (Asset::Explicit(asset), Value::Explicit(value)) => {
-                            let asset_hex = asset_to_hex(&asset.into_inner());
-                            *outputs.entry(asset_hex).or_insert(0) += value;
+                            *outputs.entry(asset.to_hex()).or_insert(0) += value;
                         }
                         _ => panic!("asset and value should be explicit here"),
                     }
@@ -466,8 +464,7 @@ impl BETransaction {
                 for output in tx.output.iter() {
                     match (output.asset, output.value) {
                         (Asset::Explicit(asset), Value::Explicit(value)) => {
-                            let asset_hex = asset_to_hex(&asset.into_inner());
-                            *outputs_asset_amounts.entry(asset_hex).or_insert(0) += value;
+                            *outputs_asset_amounts.entry(asset.to_hex()).or_insert(0) += value;
                         }
                         _ => panic!("asset and value should be explicit here"),
                     }

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -1,6 +1,5 @@
 use crate::be::{BEOutPoint, BEScript, BETransaction, BETransactionEntry, UTXOInfo, Utxos};
 use crate::util::StringSerialized;
-use bitcoin::hashes::hex::FromHex;
 use bitcoin::Network;
 use core::mem::transmute;
 use serde::{Deserialize, Serialize};
@@ -96,7 +95,7 @@ pub struct AddressAmount {
 
 impl AddressAmount {
     pub fn asset_id(&self) -> Option<elements::issuance::AssetId> {
-        self.asset_id.as_ref().and_then(|a| elements::issuance::AssetId::from_hex(a).ok())
+        self.asset_id.as_ref().and_then(|a| a.parse().ok())
     }
 }
 
@@ -561,7 +560,7 @@ impl TryFrom<&GetUnspentOutputs> for Utxos {
                 };
                 let (outpoint, utxo_info) = match &asset[..] {
                     "btc" => (
-                        BEOutPoint::new_bitcoin(bitcoin::Txid::from_hex(&e.txhash)?, e.pt_idx),
+                        BEOutPoint::new_bitcoin(e.txhash.parse()?, e.pt_idx),
                         UTXOInfo::new_bitcoin(
                             e.satoshi,
                             e.scriptpubkey.clone().into(),
@@ -570,9 +569,9 @@ impl TryFrom<&GetUnspentOutputs> for Utxos {
                         ),
                     ),
                     _ => (
-                        BEOutPoint::new_elements(elements::Txid::from_hex(&e.txhash)?, e.pt_idx),
+                        BEOutPoint::new_elements(e.txhash.parse()?, e.pt_idx),
                         UTXOInfo::new_elements(
-                            elements::issuance::AssetId::from_hex(asset)?,
+                            asset.parse()?,
                             e.satoshi,
                             e.scriptpubkey.clone().into(),
                             height,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -94,6 +94,12 @@ pub struct AddressAmount {
     pub asset_id: Option<String>,
 }
 
+impl AddressAmount {
+    pub fn asset_id(&self) -> Option<elements::issuance::AssetId> {
+        self.asset_id.as_ref().and_then(|a| elements::issuance::AssetId::from_hex(a).ok())
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct LoginData {
     pub wallet_hash_id: String,

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -1,6 +1,4 @@
-use crate::be::{
-    AssetId, BEOutPoint, BEScript, BETransaction, BETransactionEntry, UTXOInfo, Utxos,
-};
+use crate::be::{BEOutPoint, BEScript, BETransaction, BETransactionEntry, UTXOInfo, Utxos};
 use crate::util::StringSerialized;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::Network;
@@ -13,7 +11,7 @@ use crate::scripts::ScriptType;
 use bitcoin::util::address::AddressType;
 use bitcoin::util::bip32::{ChildNumber, DerivationPath};
 use chrono::{DateTime, NaiveDateTime, Utc};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::Display;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -465,19 +463,6 @@ impl Default for Settings {
             pricing,
             sound: false,
         }
-    }
-}
-
-impl AddressAmount {
-    pub fn asset(&self) -> Option<AssetId> {
-        if let Some(asset_id) = self.asset_id.as_ref() {
-            let vec = hex::decode(asset_id).ok();
-            if let Some(mut vec) = vec {
-                vec.reverse();
-                return (&vec[..]).try_into().ok();
-            }
-        }
-        None
     }
 }
 

--- a/subprojects/gdk_rust/gdk_common/src/network.rs
+++ b/subprojects/gdk_rust/gdk_common/src/network.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use bitcoin::hashes::{hex::FromHex, sha256, Hash};
+use bitcoin::hashes::{sha256, Hash};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::util::bip32::{DerivationPath, ExtendedPubKey};
 use serde::{Deserialize, Serialize};
@@ -76,7 +76,7 @@ impl Network {
 
     pub fn policy_asset_id(&self) -> Result<elements::issuance::AssetId, Error> {
         if let Some(a) = self.policy_asset.as_ref() {
-            Ok(elements::issuance::AssetId::from_hex(a)?)
+            Ok(a.parse()?)
         } else {
             Err("no policy asset".into())
         }

--- a/subprojects/gdk_rust/gdk_common/src/network.rs
+++ b/subprojects/gdk_rust/gdk_common/src/network.rs
@@ -1,11 +1,7 @@
-use crate::be::asset_to_bin;
-use crate::be::AssetId;
 use crate::error::Error;
-use bitcoin::hashes::{sha256, Hash};
+use bitcoin::hashes::{hex::FromHex, sha256, Hash};
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::util::bip32::{DerivationPath, ExtendedPubKey};
-use elements::confidential::Asset;
-use elements::{confidential, issuance};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
@@ -78,18 +74,12 @@ impl Network {
         }
     }
 
-    pub fn policy_asset_id(&self) -> Result<AssetId, Error> {
-        if let Some(str) = self.policy_asset.as_ref() {
-            Ok(asset_to_bin(str)?)
+    pub fn policy_asset_id(&self) -> Result<elements::issuance::AssetId, Error> {
+        if let Some(a) = self.policy_asset.as_ref() {
+            Ok(elements::issuance::AssetId::from_hex(a)?)
         } else {
             Err("no policy asset".into())
         }
-    }
-
-    pub fn policy_asset(&self) -> Result<Asset, Error> {
-        let asset_id = self.policy_asset_id()?;
-        let asset_id = issuance::AssetId::from_slice(&asset_id)?;
-        Ok(confidential::Asset::Explicit(asset_id))
     }
 
     pub fn registry_base_url(&self) -> Result<String, Error> {

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -863,7 +863,7 @@ pub fn create_tx(
     }
 
     let mut template_tx = None;
-    let mut change_addresses = HashMap::new();
+    let mut change_addresses = vec![];
 
     // When a previous transaction is replaced, use it as a template for the new transaction
     if let Some(ref prev_txitem) = request.previous_transaction {
@@ -885,7 +885,7 @@ pub fn create_tx(
                 let change_address = prev_tx
                     .output_address(vout, network.id())
                     .expect("own change addresses to have address representation");
-                change_addresses.insert(policy_asset.to_string(), change_address);
+                change_addresses.push(change_address);
                 false
             } else {
                 true
@@ -1070,7 +1070,7 @@ pub fn create_tx(
         &acc_store.unblinded,
     ); // Vec<Change> asset, value
     for (i, change) in changes.iter().enumerate() {
-        let change_address = change_addresses.remove(&change.asset).map_or_else(
+        let change_address = change_addresses.pop().map_or_else(
             || -> Result<_, Error> {
                 let change_index = acc_store.indexes.internal + i as u32 + 1;
                 Ok(account.derive_address(true, change_index)?.to_string())

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -872,14 +872,13 @@ pub fn create_tx(
         }
 
         let prev_tx = BETransaction::from_hex(&prev_txitem.transaction, network.id())?;
-        let policy_asset = network.policy_asset.as_deref().unwrap_or("btc");
 
         let store_read = account.store.read()?;
         let acc_store = store_read.account_cache(account.num())?;
 
         // Strip the mining fee change output from the transaction, keeping the change address for reuse
         template_tx = Some(prev_tx.filter_outputs(&acc_store.unblinded, |vout, script, asset| {
-            if asset.map_or(true, |a| a == policy_asset)
+            if asset.map_or(true, |a| a == "btc")
                 && account.get_wallet_chain_type(&script) == Some(1)
             {
                 let change_address = prev_tx

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -302,8 +302,7 @@ impl Account {
                     .map(|(outpoint, output, path)| {
                         (
                             outpoint,
-                            UTXOInfo::new(
-                                "btc".to_string(),
+                            UTXOInfo::new_bitcoin(
                                 output.value,
                                 output.script_pubkey.into(),
                                 height.clone(),
@@ -341,8 +340,8 @@ impl Account {
                                     }
                                     return Some((
                                         outpoint,
-                                        UTXOInfo::new(
-                                            unblinded.asset().to_hex(),
+                                        UTXOInfo::new_elements(
+                                            unblinded.asset(),
                                             unblinded.value,
                                             output.script_pubkey.into(),
                                             height.clone(),

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -205,11 +205,11 @@ impl Account {
                 ..Default::default()
             };
 
-            let policy_asset = match self.network.policy_asset_id() {
-                Ok(asset_id) => Some(elements::confidential::Asset::Explicit(asset_id)),
-                Err(_) => None,
-            };
-            let fee = tx.fee(&acc_store.all_txs, &acc_store.unblinded, &policy_asset)?;
+            let fee = tx.fee(
+                &acc_store.all_txs,
+                &acc_store.unblinded,
+                &self.network.policy_asset_id().ok(),
+            )?;
             trace!("tx_id {} fee {}", tx_id, fee);
 
             let satoshi =
@@ -1086,11 +1086,9 @@ pub fn create_tx(
     // randomize inputs and outputs, BIP69 has been rejected because lacks wallets adoption
     tx.scramble();
 
-    let policy_asset = match network.policy_asset_id() {
-        Ok(asset_id) => Some(elements::confidential::Asset::Explicit(asset_id)),
-        Err(_) => None,
-    };
-    let fee_val = tx.fee(&acc_store.all_txs, &acc_store.unblinded, &policy_asset)?; // recompute exact fee_val from built tx
+    let policy_asset = network.policy_asset_id().ok();
+    // recompute exact fee_val from built tx
+    let fee_val = tx.fee(&acc_store.all_txs, &acc_store.unblinded, &policy_asset)?;
     tx.add_fee_if_elements(fee_val, &policy_asset)?;
 
     info!("created tx fee {:?}", fee_val);

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -878,9 +878,7 @@ pub fn create_tx(
 
         // Strip the mining fee change output from the transaction, keeping the change address for reuse
         template_tx = Some(prev_tx.filter_outputs(&acc_store.unblinded, |vout, script, asset| {
-            if asset.map_or(true, |a| a == "btc")
-                && account.get_wallet_chain_type(&script) == Some(1)
-            {
+            if asset == None && account.get_wallet_chain_type(&script) == Some(1) {
                 let change_address = prev_tx
                     .output_address(vout, network.id())
                     .expect("own change addresses to have address representation");

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -7,6 +7,7 @@ use log::{debug, info, trace, warn};
 use rand::Rng;
 
 use bitcoin::blockdata::script;
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{self, Message};
 use bitcoin::util::address::Payload;
@@ -341,7 +342,7 @@ impl Account {
                                     return Some((
                                         outpoint,
                                         UTXOInfo::new(
-                                            unblinded.asset_hex(),
+                                            unblinded.asset().to_hex(),
                                             unblinded.value,
                                             output.script_pubkey.into(),
                                             height.clone(),

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -1011,7 +1011,7 @@ pub fn create_tx(
         let mut needs = tx.needs(
             fee_rate,
             send_all,
-            network.policy_asset.clone(),
+            network.policy_asset_id().ok(),
             &acc_store.all_txs,
             &acc_store.unblinded,
             account.script_type,
@@ -1063,7 +1063,7 @@ pub fn create_tx(
     );
     let changes = tx.changes(
         estimated_fee,
-        network.policy_asset.clone(),
+        network.policy_asset_id().ok(),
         &acc_store.all_txs,
         &acc_store.unblinded,
     ); // Vec<Change> asset, value

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -23,6 +23,7 @@ use crate::error::Error;
 use crate::interface::{ElectrumUrl, WalletCtx};
 use crate::store::*;
 
+use bitcoin::hashes::hex::ToHex;
 use bitcoin::secp256k1::{self, Secp256k1, SecretKey};
 use bitcoin::util::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey};
 
@@ -1412,12 +1413,7 @@ impl Syncer {
                     asset_commitment,
                 )?;
 
-                info!(
-                    "Unblinded outpoint:{} asset:{} value:{}",
-                    outpoint,
-                    hex::encode(&asset),
-                    value
-                );
+                info!("Unblinded outpoint:{} asset:{} value:{}", outpoint, asset.to_hex(), value);
 
                 let unblinded = Unblinded {
                     asset,
@@ -1429,7 +1425,7 @@ impl Syncer {
             }
             (Asset::Explicit(asset_id), confidential::Value::Explicit(satoshi), _) => {
                 let unblinded = Unblinded {
-                    asset: asset_id.into_inner().into_inner(),
+                    asset: asset_id,
                     value: satoshi,
                     abf: [0u8; 32],
                     vbf: [0u8; 32],


### PR DESCRIPTION
Use `AssetId` rather than strings internally, use less "btc"