### PR TITLE
Refactor gdk_rust.h interface

### DIFF
--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -87,7 +87,7 @@ namespace sdk {
         nlohmann::json network(m_net_params.get_json());
         network["proxy"] = net_params.value("proxy", std::string{});
         network["state_dir"] = gdk_config().value("datadir", std::string{}) + "/state";
-        GDKRUST_create_session(&m_session, convert_json(network).get());
+        GDKRUST_create_session(&m_session, network.dump().c_str());
     }
 
     ga_rust::~ga_rust()

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -21,18 +21,6 @@ namespace sdk {
     namespace {
         static const std::string TOR_SOCKS5_PREFIX("socks5://");
 
-        static nlohmann::json convert_serde(GDKRUST_json* json)
-        {
-            char* output;
-            GDKRUST_convert_json_to_string(json, &output);
-            GDKRUST_destroy_json(json);
-
-            auto cppjson = nlohmann::json::parse(output);
-            GDKRUST_destroy_string(output);
-
-            return cppjson;
-        }
-
         static std::pair<std::string, std::string> get_exception_details(const nlohmann::json& details)
         {
             std::pair<std::string, std::string> ret;
@@ -262,10 +250,10 @@ namespace sdk {
         return call_session("get_transactions", actual_details);
     }
 
-    void ga_rust::GDKRUST_notif_handler(void* self_context, struct GDKRUST_json* json)
+    void ga_rust::GDKRUST_notif_handler(void* self_context, char* json)
     {
         ga_rust* self = static_cast<ga_rust*>(self_context);
-        auto notification = convert_serde(json);
+        auto notification = nlohmann::json::parse(json);
         if (notification.at("event") == "transaction") {
             // FIXME: Get the actual subaccounts affected from the notification
             // See gdk_rust/gdk_electrum/src/lib.rs: "// TODO account number"

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -69,7 +69,7 @@ namespace sdk {
 
     ga_rust::~ga_rust()
     {
-        call_session("destroy_session", nlohmann::json());
+        GDKRUST_destroy_session(m_session);
         // gdk_rust cleanup
     }
 

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -21,17 +21,6 @@ namespace sdk {
     namespace {
         static const std::string TOR_SOCKS5_PREFIX("socks5://");
 
-        using json_ptr = std::shared_ptr<GDKRUST_json>;
-
-        inline json_ptr convert_json(const std::string& v)
-        {
-            GDKRUST_json* p;
-            GDKRUST_convert_string_to_json(v.c_str(), &p);
-            return json_ptr(p, GDKRUST_destroy_json);
-        }
-
-        inline json_ptr convert_json(const nlohmann::json& v) { return convert_json(v.dump()); }
-
         static nlohmann::json convert_serde(GDKRUST_json* json)
         {
             char* output;
@@ -582,7 +571,7 @@ namespace sdk {
 
     int32_t ga_rust::spv_verify_tx(const nlohmann::json& details)
     {
-        return GDKRUST_spv_verify_tx(convert_json(details).get());
+        return GDKRUST_spv_verify_tx(details.dump().c_str());
     }
 
 } // namespace sdk

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -63,7 +63,8 @@ namespace sdk {
         nlohmann::json network(m_net_params.get_json());
         network["proxy"] = net_params.value("proxy", std::string{});
         network["state_dir"] = gdk_config().value("datadir", std::string{}) + "/state";
-        GDKRUST_create_session(&m_session, network.dump().c_str());
+        const auto res = GDKRUST_create_session(&m_session, network.dump().c_str());
+        GDK_RUNTIME_ASSERT(res == GA_OK);
     }
 
     ga_rust::~ga_rust()

--- a/src/ga_rust.cpp
+++ b/src/ga_rust.cpp
@@ -255,6 +255,7 @@ namespace sdk {
     {
         ga_rust* self = static_cast<ga_rust*>(self_context);
         auto notification = nlohmann::json::parse(json);
+        GDKRUST_destroy_string(json);
         if (notification.at("event") == "transaction") {
             // FIXME: Get the actual subaccounts affected from the notification
             // See gdk_rust/gdk_electrum/src/lib.rs: "// TODO account number"

--- a/src/ga_rust.hpp
+++ b/src/ga_rust.hpp
@@ -2,8 +2,6 @@
 
 #include "session_impl.hpp"
 
-struct GDKRUST_session;
-
 namespace ga {
 namespace sdk {
     struct tor_controller;
@@ -145,7 +143,7 @@ namespace sdk {
         std::shared_ptr<tor_controller> m_tor_ctrl;
         bool m_reconnect_restart;
 
-        struct GDKRUST_session* m_session;
+        void* m_session;
     };
 
 } // namespace sdk

--- a/src/ga_rust.hpp
+++ b/src/ga_rust.hpp
@@ -139,7 +139,7 @@ namespace sdk {
     private:
         nlohmann::json call_session(const std::string& method, const nlohmann::json& input) const;
 
-        static void GDKRUST_notif_handler(void* self_context, struct GDKRUST_json* json);
+        static void GDKRUST_notif_handler(void* self_context, char* json);
         void set_notification_handler(GA_notification_handler handler, void* context);
 
         std::shared_ptr<tor_controller> m_tor_ctrl;

--- a/subprojects/gdk_rust/apple-exported-symbols
+++ b/subprojects/gdk_rust/apple-exported-symbols
@@ -1,5 +1,6 @@
 _GDKRUST_create_session
 _GDKRUST_call_session
 _GDKRUST_destroy_string
+_GDKRUST_destroy_session
 _GDKRUST_set_notification_handler
 _GDKRUST_spv_verify_tx

--- a/subprojects/gdk_rust/apple-exported-symbols
+++ b/subprojects/gdk_rust/apple-exported-symbols
@@ -3,6 +3,4 @@ _GDKRUST_call_session
 _GDKRUST_destroy_json
 _GDKRUST_destroy_string
 _GDKRUST_set_notification_handler
-_GDKRUST_convert_json_to_string
-_GDKRUST_convert_string_to_json
 _GDKRUST_spv_verify_tx

--- a/subprojects/gdk_rust/apple-exported-symbols
+++ b/subprojects/gdk_rust/apple-exported-symbols
@@ -1,6 +1,5 @@
 _GDKRUST_create_session
 _GDKRUST_call_session
-_GDKRUST_destroy_json
 _GDKRUST_destroy_string
 _GDKRUST_set_notification_handler
 _GDKRUST_spv_verify_tx

--- a/subprojects/gdk_rust/exported-symbols
+++ b/subprojects/gdk_rust/exported-symbols
@@ -3,6 +3,4 @@ GDKRUST_call_session
 GDKRUST_destroy_json
 GDKRUST_destroy_string
 GDKRUST_set_notification_handler
-GDKRUST_convert_json_to_string
-GDKRUST_convert_string_to_json
 GDKRUST_spv_verify_tx

--- a/subprojects/gdk_rust/exported-symbols
+++ b/subprojects/gdk_rust/exported-symbols
@@ -1,5 +1,6 @@
 GDKRUST_create_session
 GDKRUST_call_session
 GDKRUST_destroy_string
+GDKRUST_destroy_session
 GDKRUST_set_notification_handler
 GDKRUST_spv_verify_tx

--- a/subprojects/gdk_rust/exported-symbols
+++ b/subprojects/gdk_rust/exported-symbols
@@ -1,6 +1,5 @@
 GDKRUST_create_session
 GDKRUST_call_session
-GDKRUST_destroy_json
 GDKRUST_destroy_string
 GDKRUST_set_notification_handler
 GDKRUST_spv_verify_tx

--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -1,7 +1,6 @@
 use crate::be::{BEOutPoint, BEScript, BETransaction, BETransactionEntry, UTXOInfo, Utxos};
 use crate::util::StringSerialized;
 use bitcoin::Network;
-use core::mem::transmute;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -14,16 +13,6 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::Display;
 use std::time::{SystemTime, UNIX_EPOCH};
-
-#[derive(Debug)]
-#[repr(C)]
-pub struct GDKRUST_json(pub serde_json::Value);
-
-impl GDKRUST_json {
-    pub fn new(data: serde_json::Value) -> *const GDKRUST_json {
-        unsafe { transmute(Box::new(GDKRUST_json(data))) }
-    }
-}
 
 pub type Balances = HashMap<String, i64>;
 

--- a/subprojects/gdk_rust/gdk_common/src/session.rs
+++ b/subprojects/gdk_rust/gdk_common/src/session.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 
 pub trait Session<E> {
     // fn create_session(network: Network) -> Result<Self::Value, E>;
-    fn destroy_session(&mut self) -> Result<(), E>;
     fn poll_session(&self) -> Result<(), E>;
     fn connect(&mut self, net_params: &Value) -> Result<(), E>;
     fn disconnect(&mut self) -> Result<(), E>;

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -36,7 +36,7 @@ use gdk_common::password::Password;
 use gdk_common::session::Session;
 use gdk_common::wally::{
     self, asset_blinding_key_from_seed, asset_blinding_key_to_ec_private_key, asset_unblind,
-    MasterBlindingKey,
+    make_str, MasterBlindingKey,
 };
 
 use elements::confidential::{self, Asset, Nonce};
@@ -90,7 +90,7 @@ pub struct Headers {
 
 #[derive(Clone)]
 pub struct NativeNotif(
-    pub Option<(extern "C" fn(*const libc::c_void, *const GDKRUST_json), *const libc::c_void)>,
+    pub Option<(extern "C" fn(*const libc::c_void, *const libc::c_char), *const libc::c_void)>,
 );
 unsafe impl Send for NativeNotif {}
 
@@ -133,7 +133,7 @@ fn notify(notif: NativeNotif, data: Value) {
     info!("push notification: {:?}", data);
     if let Some((handler, self_context)) = notif.0 {
         // TODO check the native pointer is still alive
-        handler(self_context, GDKRUST_json::new(data));
+        handler(self_context, make_str(data.to_string()));
     } else {
         warn!("no registered handler to receive notification");
     }

--- a/subprojects/gdk_rust/gdk_electrum/src/lib.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/lib.rs
@@ -297,11 +297,6 @@ fn make_txlist_item(tx: &TransactionMeta) -> TxListItem {
 impl Session<Error> for ElectrumSession {
     // type Value = ElectrumSession;
 
-    fn destroy_session(&mut self) -> Result<(), Error> {
-        self.wallet = None;
-        Ok(())
-    }
-
     fn poll_session(&self) -> Result<(), Error> {
         Err(Error::Generic("implementme: ElectrumSession poll_session".into()))
     }

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -50,13 +50,6 @@ GDK_API int GDKRUST_spv_verify_tx(const char *input);
 GDK_API int GDKRUST_set_notification_handler(struct GDKRUST_session* session, GDKRUST_notification_handler handler, void *self_context);
 
 /**
- * Free a GDKRUST_json object.
- *
- * :param json: GDKRUST_json object to free.
- */
-GDK_API int GDKRUST_destroy_json(GDKRUST_json* json);
-
-/**
  * Free a string returned by the api.
  *
  * :param str: The string to free.

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -49,9 +49,6 @@ GDK_API int GDKRUST_spv_verify_tx(const char *input);
  */
 GDK_API int GDKRUST_set_notification_handler(struct GDKRUST_session* session, GDKRUST_notification_handler handler, void *self_context);
 
-GDK_API int GDKRUST_convert_json_to_string(const GDKRUST_json* json, char** output);
-
-GDK_API int GDKRUST_convert_string_to_json(const char* input, GDKRUST_json** output);
 /**
  * Free a GDKRUST_json object.
  *

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -41,7 +41,7 @@ GDK_API int GDKRUST_create_session(struct GDKRUST_session** session, const char*
 
 GDK_API int GDKRUST_call_session(struct GDKRUST_session* session, const char *method, const char *input, char** output);
 
-GDK_API int GDKRUST_spv_verify_tx(const GDKRUST_json* json);
+GDK_API int GDKRUST_spv_verify_tx(const char *input);
 
 #ifndef SWIG
 /**

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -29,7 +29,7 @@ typedef struct GDKRUST_session GDKRUST_session;
 typedef struct GDKRUST_json GDKRUST_json;
 
 /** A notification handler */
-typedef void (*GDKRUST_notification_handler)(void *self_context, GDKRUST_json* details);
+typedef void (*GDKRUST_notification_handler)(void *self_context, char *details);
 
 /**
  * Create a new session.

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -37,7 +37,7 @@ typedef void (*GDKRUST_notification_handler)(void *self_context, GDKRUST_json* d
  * :param session: Destination for the resulting session.
  *|     Returned session should be freed using `GA_destroy_session`.
  */
-GDK_API int GDKRUST_create_session(struct GDKRUST_session** session, GDKRUST_json *networks);
+GDK_API int GDKRUST_create_session(struct GDKRUST_session** session, const char* network);
 
 GDK_API int GDKRUST_call_session(struct GDKRUST_session* session, const char *method, const GDKRUST_json* input, GDKRUST_json** output);
 

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -25,9 +25,6 @@ extern "C" {
 /** A server session */
 typedef struct GDKRUST_session GDKRUST_session;
 
-/** A Parsed JSON object */
-typedef struct GDKRUST_json GDKRUST_json;
-
 /** A notification handler */
 typedef void (*GDKRUST_notification_handler)(void *self_context, char *details);
 

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -32,7 +32,7 @@ typedef void (*GDKRUST_notification_handler)(void *self_context, char *details);
  * Create a new session.
  *
  * :param session: Destination for the resulting session.
- *|     Returned session should be freed using `GA_destroy_session`.
+ *|     Returned session should be freed using `GDKRUST_destroy_session`.
  */
 GDK_API int GDKRUST_create_session(GDKRUST_session* session, const char* network);
 
@@ -53,6 +53,12 @@ GDK_API int GDKRUST_set_notification_handler(GDKRUST_session session, GDKRUST_no
  */
 GDK_API void GDKRUST_destroy_string(char* str);
 
+/**
+ * Free a session created by the api.
+ *
+ * :param session: The session to free.
+ */
+GDK_API void GDKRUST_destroy_session(GDKRUST_session session);
 
 #endif /* SWIG */
 

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -39,7 +39,7 @@ typedef void (*GDKRUST_notification_handler)(void *self_context, GDKRUST_json* d
  */
 GDK_API int GDKRUST_create_session(struct GDKRUST_session** session, const char* network);
 
-GDK_API int GDKRUST_call_session(struct GDKRUST_session* session, const char *method, const GDKRUST_json* input, GDKRUST_json** output);
+GDK_API int GDKRUST_call_session(struct GDKRUST_session* session, const char *method, const char *input, char** output);
 
 GDK_API int GDKRUST_spv_verify_tx(const GDKRUST_json* json);
 

--- a/subprojects/gdk_rust/gdk_rust.h
+++ b/subprojects/gdk_rust/gdk_rust.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 /** A server session */
-typedef struct GDKRUST_session GDKRUST_session;
+typedef void* GDKRUST_session;
 
 /** A notification handler */
 typedef void (*GDKRUST_notification_handler)(void *self_context, char *details);
@@ -34,9 +34,9 @@ typedef void (*GDKRUST_notification_handler)(void *self_context, char *details);
  * :param session: Destination for the resulting session.
  *|     Returned session should be freed using `GA_destroy_session`.
  */
-GDK_API int GDKRUST_create_session(struct GDKRUST_session** session, const char* network);
+GDK_API int GDKRUST_create_session(GDKRUST_session* session, const char* network);
 
-GDK_API int GDKRUST_call_session(struct GDKRUST_session* session, const char *method, const char *input, char** output);
+GDK_API int GDKRUST_call_session(GDKRUST_session session, const char *method, const char *input, char** output);
 
 GDK_API int GDKRUST_spv_verify_tx(const char *input);
 
@@ -44,7 +44,7 @@ GDK_API int GDKRUST_spv_verify_tx(const char *input);
 /**
  * Set a handler to be called when notifications arrive.
  */
-GDK_API int GDKRUST_set_notification_handler(struct GDKRUST_session* session, GDKRUST_notification_handler handler, void *self_context);
+GDK_API int GDKRUST_set_notification_handler(GDKRUST_session session, GDKRUST_notification_handler handler, void *self_context);
 
 /**
  * Free a string returned by the api.

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -427,12 +427,11 @@ where
 }
 
 #[no_mangle]
-pub extern "C" fn GDKRUST_destroy_string(ptr: *mut c_char) -> i32 {
+pub extern "C" fn GDKRUST_destroy_string(ptr: *mut c_char) {
     unsafe {
         // retake pointer and drop
         let _ = CString::from_raw(ptr);
     }
-    GA_OK
 }
 
 #[no_mangle]

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -64,13 +64,6 @@ macro_rules! ok {
     };
 }
 
-macro_rules! json_res {
-    ($t:expr, $x:expr, $ret:expr) => {{
-        let x = json!($x);
-        ok!($t, GDKRUST_json::new(x), $ret)
-    }};
-}
-
 macro_rules! safe_mut_ref {
     ($t:expr) => {{
         if $t.is_null() {
@@ -438,36 +431,6 @@ where
         // "auth_handler_get_status" => Ok(auth_handler.to_json()),
         _ => Err(Error::Other(format!("handle_call method not found: {}", method))),
     }
-}
-
-#[no_mangle]
-pub extern "C" fn GDKRUST_convert_json_to_string(
-    json: *const GDKRUST_json,
-    ret: *mut *const c_char,
-) -> i32 {
-    let json = &unsafe { &*json }.0;
-    let res = json.to_string();
-    ok!(ret, make_str(res), GA_OK)
-}
-
-#[no_mangle]
-pub extern "C" fn GDKRUST_convert_string_to_json(
-    jstr: *const c_char,
-    ret: *mut *const GDKRUST_json,
-) -> i32 {
-    let jstr = read_str(jstr);
-    let json: Value = match serde_json::from_str(&jstr) {
-        Err(err) => {
-            error!("error: {:?}", err);
-            return GA_ERROR;
-        }
-        Ok(x) => {
-            // can't easily print x because bitcoincore_rpc::Client is not serializable :(
-            // should be fixed with https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/51
-            x
-        }
-    };
-    json_res!(ret, json, GA_OK)
 }
 
 #[no_mangle]

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -316,8 +316,6 @@ where
     match method {
         "poll_session" => session.poll_session().map(|v| json!(v)).map_err(Into::into),
 
-        "destroy_session" => session.destroy_session().map(|v| json!(v)).map_err(Into::into),
-
         "connect" => session.connect(input).map(|v| json!(v)).map_err(Into::into),
 
         "disconnect" => session.disconnect().map(|v| json!(v)).map_err(Into::into),
@@ -431,6 +429,14 @@ pub extern "C" fn GDKRUST_destroy_string(ptr: *mut c_char) {
     unsafe {
         // retake pointer and drop
         let _ = CString::from_raw(ptr);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn GDKRUST_destroy_session(ptr: *mut libc::c_void) {
+    unsafe {
+        // retake pointer and drop
+        let _ = Box::from_raw(ptr as *mut GdkSession);
     }
 }
 

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -53,22 +53,6 @@ pub enum GdkBackend {
 // Macros
 //
 
-macro_rules! tryit {
-    ($x:expr) => {
-        match $x {
-            Err(err) => {
-                error!("error: {:?}", err);
-                return GA_ERROR;
-            }
-            Ok(x) => {
-                // can't easily print x because bitcoincore_rpc::Client is not serializable :(
-                // should be fixed with https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/51
-                x
-            }
-        }
-    };
-}
-
 macro_rules! ok {
     ($t:expr, $x:expr, $ret:expr) => {
         unsafe {
@@ -469,7 +453,17 @@ pub extern "C" fn GDKRUST_convert_string_to_json(
     ret: *mut *const GDKRUST_json,
 ) -> i32 {
     let jstr = read_str(jstr);
-    let json: Value = tryit!(serde_json::from_str(&jstr));
+    let json: Value = match serde_json::from_str(&jstr) {
+        Err(err) => {
+            error!("error: {:?}", err);
+            return GA_ERROR;
+        }
+        Ok(x) => {
+            // can't easily print x because bitcoincore_rpc::Client is not serializable :(
+            // should be fixed with https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/51
+            x
+        }
+    };
     json_res!(ret, json, GA_OK)
 }
 

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -23,8 +23,8 @@ use std::sync::Once;
 use std::time::{Duration, SystemTime};
 
 use gdk_common::model::{
-    CreateAccountOpt, GDKRUST_json, GetNextAccountOpt, GetTransactionsOpt, RenameAccountOpt,
-    SPVVerifyTx, SetAccountHiddenOpt, UpdateAccountOpt,
+    CreateAccountOpt, GetNextAccountOpt, GetTransactionsOpt, RenameAccountOpt, SPVVerifyTx,
+    SetAccountHiddenOpt, UpdateAccountOpt,
 };
 use gdk_common::session::Session;
 
@@ -431,16 +431,6 @@ where
         // "auth_handler_get_status" => Ok(auth_handler.to_json()),
         _ => Err(Error::Other(format!("handle_call method not found: {}", method))),
     }
-}
-
-#[no_mangle]
-pub extern "C" fn GDKRUST_destroy_json(ptr: *mut GDKRUST_json) -> i32 {
-    trace!("GA_destroy_json({:?})", ptr);
-    // TODO make sure this works
-    unsafe {
-        drop(&*ptr);
-    }
-    GA_OK
 }
 
 #[no_mangle]

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -273,7 +273,7 @@ pub extern "C" fn GDKRUST_call_session(
 #[no_mangle]
 pub extern "C" fn GDKRUST_set_notification_handler(
     sess: *mut GdkSession,
-    handler: extern "C" fn(*const libc::c_void, *const GDKRUST_json),
+    handler: extern "C" fn(*const libc::c_void, *const c_char),
     self_context: *const libc::c_void,
 ) -> i32 {
     let sess = safe_mut_ref!(sess);

--- a/subprojects/gdk_rust/src/lib.rs
+++ b/subprojects/gdk_rust/src/lib.rs
@@ -49,31 +49,6 @@ pub enum GdkBackend {
     Electrum(ElectrumSession),
 }
 
-#[derive(Debug)]
-#[repr(C)]
-pub enum GA_auth_handler {
-    Error(String),
-    Done(Value),
-}
-
-impl GA_auth_handler {
-    fn _done(res: Value) -> *const GA_auth_handler {
-        info!("GA_auth_handler::done() {:?}", res);
-        let handler = GA_auth_handler::Done(res);
-        unsafe { transmute(Box::new(handler)) }
-    }
-    fn _success() -> *const GA_auth_handler {
-        GA_auth_handler::_done(Value::Null)
-    }
-
-    fn _to_json(&self) -> Value {
-        match self {
-            GA_auth_handler::Error(err) => json!({ "status": "error", "error": err }),
-            GA_auth_handler::Done(res) => json!({ "status": "done", "result": res }),
-        }
-    }
-}
-
 //
 // Macros
 //


### PR DESCRIPTION
The initial GDK rust implementation consisted in a binary that could
replace the C++ binary. In the following iterations `gdk_rust` became
a component of the library and is called by the C++ code.
However the interface exposed by rust, `gdk_rust.h`, was never
adapted accordingly. So we had unused code, an overcomplicated
interface and some memory leaks.

This MR is an initial attempt to address those issues.
In details:
- Remove unused code
- Replace some rust macros
- Replace `GDKRUST_json` with string, since the conversion was performed every time anyway
- Remove usage of `std::mem::transmute`
- Make `GDKRUST_session` a void pointer, since C++ caller does not need to access its internal
- Add `GDKRUST_destroy_