### PR TITLE
rust: tests: cleanup to reduce flakiness

### DIFF
--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -163,7 +163,9 @@ impl Account {
         let mut my_txids: Vec<(&BETxid, &Option<u32>)> = acc_store
             .heights
             .iter()
-            .filter(|(_, height)| num_confs <= height.map_or(0, |height| tip_height - height + 1))
+            .filter(|(_, height)| {
+                num_confs <= height.map_or(0, |height| (tip_height + 1).saturating_sub(height))
+            })
             .collect();
         my_txids.sort_by(|a, b| {
             let height_cmp = b.1.unwrap_or(std::u32::MAX).cmp(&a.1.unwrap_or(std::u32::MAX));
@@ -275,7 +277,7 @@ impl Account {
         let mut utxos = vec![];
         let spent = self.spent()?;
         for (tx_id, height) in acc_store.heights.iter() {
-            if num_confs > height.map_or(0, |height| tip_height - height + 1) {
+            if num_confs > height.map_or(0, |height| (tip_height + 1).saturating_sub(height)) {
                 continue;
             }
 

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -381,6 +381,7 @@ fn labels() {
     let signed_tx = test_session.session.sign_transaction(&tx).unwrap();
     let txid = test_session.session.broadcast_transaction(&signed_tx.hex).unwrap();
     test_session.wait_account_tx(account1.account_num, &txid);
+    test_session.wait_account_tx(account2.account_num, &txid);
 
     // Memos should be set across all accounts
     assert_eq!(test_session.get_tx_from_list(account1.account_num, &txid).memo, "Foo, Bar Foo");
@@ -566,6 +567,7 @@ fn spv_cross_validation_session() {
 
     // Extend session1, making it the best chain
     test_session1.node_generate(11);
+    test_session1.wait_block_status_change();
     let cross_result = test_session1.wait_spv_cross_validation_change(true);
     assert!(cross_result.is_valid());
     assert_eq!(test_session1.get_tx_from_list(0, &txid).spv_verified, "verified");

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -138,7 +138,7 @@ fn subaccounts_bitcoin() {
 
 #[test]
 fn subaccounts_liquid() {
-    subaccounts(false);
+    subaccounts(true);
 }
 
 fn subaccounts(is_liquid: bool) {

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -218,15 +218,15 @@ fn subaccounts(is_liquid: bool) {
 
     // Send some to account #1
     let sat = 98766;
-    test_session.node_sendtoaddress(&acc1_address.address, sat, None);
-    test_session.wait_tx_status_change();
+    let txid = test_session.node_sendtoaddress(&acc1_address.address, sat, None);
+    test_session.wait_account_tx(1, &txid);
     *balances.entry(1).or_insert(0) += sat;
     check_account_balances(&test_session, &balances);
 
     // Send some to account #2
     let sat = 67899;
-    test_session.node_sendtoaddress(&acc2_address.address, sat, None);
-    test_session.wait_tx_status_change();
+    let txid = test_session.node_sendtoaddress(&acc2_address.address, sat, None);
+    test_session.wait_account_tx(2, &txid);
     *balances.entry(2).or_insert(0) += sat;
     check_account_balances(&test_session, &balances);
 
@@ -389,8 +389,8 @@ fn labels() {
 
     // Fund account #1
     let acc1_address = test_session.get_receive_address(account1.account_num);
-    test_session.node_sendtoaddress(&acc1_address.address, 9876543, None);
-    test_session.wait_tx_status_change();
+    let txid = test_session.node_sendtoaddress(&acc1_address.address, 9876543, None);
+    test_session.wait_account_tx(account1.account_num, &txid);
 
     // Send from account #1 to account #2 with a memo
     let mut create_opt = CreateTransaction::default();
@@ -429,8 +429,12 @@ fn rbf() {
             subaccount: 1,
         })
         .unwrap();
-    test_session.node_sendtoaddress(&test_session.get_receive_address(1).address, 9876543, None);
-    test_session.wait_tx_status_change();
+    let txid = test_session.node_sendtoaddress(
+        &test_session.get_receive_address(1).address,
+        9876543,
+        None,
+    );
+    test_session.wait_account_tx(1, &txid);
 
     // Create transaction for replacement
     let mut create_opt = CreateTransaction::default();
@@ -566,7 +570,7 @@ fn spv_cross_validation_session() {
     // Send a payment to session1
     let ap = test_session1.get_receive_address(0);
     let txid = test_session1.node_sendtoaddress(&ap.address, 999999, None);
-    test_session1.wait_tx_status_change();
+    test_session1.wait_account_tx(0, &txid);
     let txitem = test_session1.get_tx_from_list(0, &txid);
     assert_eq!(txitem.block_height, 0);
     assert_eq!(txitem.spv_verified, "unconfirmed");

--- a/subprojects/gdk_rust/tests/integration.rs
+++ b/subprojects/gdk_rust/tests/integration.rs
@@ -318,15 +318,15 @@ fn subaccounts(is_liquid: bool) {
     new_session.login(&mnemonic, None).unwrap();
 
     // Wait until all subaccounts have been recovered
-    let mut i = 120;
+    let mut i = 60;
     let subaccounts = loop {
-        assert!(i > 0, "1 minute without updates");
+        assert!(i > 0, "timeout waiting for updates");
         i -= 1;
         let subaccounts = new_session.get_subaccounts().unwrap();
         if subaccounts.len() == balances.len() {
             break subaccounts;
         }
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        std::thread::sleep(std::time::Duration::from_secs(1));
     };
 
     let btc_key = if is_liquid {
@@ -343,14 +343,14 @@ fn subaccounts(is_liquid: bool) {
             subaccount: subaccount.account_num,
             num_confs: None,
         };
-        let mut i = 120;
+        let mut i = 60;
         loop {
-            assert!(i > 0, "1 minute without updates");
+            assert!(i > 0, "timeout waiting for updates");
             i -= 1;
             if new_session.get_transactions(&opt).unwrap().0.len() > 0 {
                 break;
             }
-            std::thread::sleep(std::time::Duration::from_millis(500));
+            std::thread::sleep(std::time::Duration::from_secs(1));
         }
 
         let opt = GetBalanceOpt {
@@ -482,7 +482,7 @@ fn rbf() {
         if list.iter().all(|e| e.txhash != txid1) {
             break;
         }
-        assert!(i < 59, "replaced transaction didn't disappear after 1 minute");
+        assert!(i < 59, "timeout waiting for replaced transaction to disappear");
     }
 
     // Transactions that are not properly signed should be rejected, to prevent the user from

--- a/subprojects/gdk_rust/tests/test_session.rs
+++ b/subprojects/gdk_rust/tests/test_session.rs
@@ -865,14 +865,13 @@ impl TestSession {
         let req_rate = req_rate as f64 / 1000.0;
         assert!(
             ((real_rate - req_rate).abs() / real_rate) < max_perc_diff,
-            format!("real_rate:{} req_rate:{}", real_rate, req_rate)
+            "real_rate:{} req_rate:{}",
+            real_rate,
+            req_rate
         ); // percentage difference between fee rate requested vs real fee
         let relay_fee =
             self.node.client.get_network_info().unwrap().relay_fee.as_sat() as f64 / 1000.0;
-        assert!(
-            real_rate > relay_fee,
-            format!("fee rate:{} is under relay_fee:{}", real_rate, relay_fee)
-        );
+        assert!(real_rate > relay_fee, "fee rate:{} is under relay_fee:{}", real_rate, relay_fee);
     }
 
     /// ask the blockcain tip to electrs


### PR DESCRIPTION
With the recent `cargo test` changes,
now tests are run with higher parallelism,
which make them even more flaky.
This MR attempts to fix some of the issues that
arose in some of the past CI runs.