### PR TITLE
rust: implement "manual" utxos_strategy

### DIFF
--- a/subprojects/gdk_rust/gdk_common/src/model.rs
+++ b/subprojects/gdk_rust/gdk_common/src/model.rs
@@ -93,6 +93,22 @@ pub struct LoginData {
     pub wallet_hash_id: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum UtxoStrategy {
+    /// Add utxos until the addressees amounts and fees are covered
+    Default,
+
+    /// Uses all and only the utxos specified by the caller
+    Manual,
+}
+
+impl Default for UtxoStrategy {
+    fn default() -> Self {
+        UtxoStrategy::Default
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct CreateTransaction {
     #[serde(default)]
@@ -113,6 +129,8 @@ pub struct CreateTransaction {
     pub num_confs: u32,
     #[serde(default)]
     pub confidential_utxos_only: bool,
+    #[serde(default)]
+    pub utxo_strategy: UtxoStrategy,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]


### PR DESCRIPTION
Unlike "default", which was already available, "manual" will use all
and only the utxos passed in.

