### PR TITLE
freeze setuptools and fix address parsing for liquid testnet

### DIFF
--- a/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
+++ b/subprojects/gdk_rust/gdk_common/src/be/transaction.rs
@@ -2,8 +2,8 @@ use crate::be::*;
 use crate::error::Error;
 use crate::model::Balances;
 use crate::scripts::{p2pkh_script, ScriptType};
+use crate::NetworkId;
 use crate::{bail, ensure};
-use crate::{ElementsNetwork, NetworkId, LIQUID_TESTNET};
 use bitcoin::blockdata::script::Instruction;
 use bitcoin::consensus::encode::deserialize as btc_des;
 use bitcoin::consensus::encode::serialize as btc_ser;
@@ -12,10 +12,10 @@ use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{self, Message, Secp256k1, Signature};
 use bitcoin::util::bip143::SigHashCache;
 use bitcoin::{PublicKey, SigHashType};
+use elements::confidential;
 use elements::confidential::{Asset, Value};
 use elements::encode::deserialize as elm_des;
 use elements::encode::serialize as elm_ser;
-use elements::{confidential, AddressParams};
 use elements::{TxInWitness, TxOutWitness};
 use log::{info, trace};
 use rand::seq::SliceRandom;
@@ -184,11 +184,7 @@ impl BETransaction {
             (BETransaction::Elements(tx), NetworkId::Elements(net)) => {
                 // Note we are returning the unconfidential address, because recipient blinding pub key is not in the transaction
                 let script = &tx.output[vout as usize].script_pubkey;
-                let params = match net {
-                    ElementsNetwork::Liquid => &AddressParams::LIQUID,
-                    ElementsNetwork::LiquidTestnet => &LIQUID_TESTNET,
-                    ElementsNetwork::ElementsRegtest => &AddressParams::ELEMENTS,
-                };
+                let params = net.address_params();
                 elements::Address::from_script(script, None, params).map(|a| a.to_string())
             }
             _ => panic!("Invalid BETransaction and NetworkId combination"),

--- a/subprojects/gdk_rust/gdk_common/src/network.rs
+++ b/subprojects/gdk_rust/gdk_common/src/network.rs
@@ -71,6 +71,16 @@ pub const LIQUID_TESTNET: elements::AddressParams = elements::AddressParams {
     blech_hrp: "tlq",
 };
 
+impl ElementsNetwork {
+    pub fn address_params(self: ElementsNetwork) -> &'static elements::AddressParams {
+        match self {
+            ElementsNetwork::Liquid => &elements::AddressParams::LIQUID,
+            ElementsNetwork::LiquidTestnet => &LIQUID_TESTNET,
+            ElementsNetwork::ElementsRegtest => &elements::AddressParams::ELEMENTS,
+        }
+    }
+}
+
 impl Network {
     pub fn id(&self) -> NetworkId {
         match (self.liquid, self.mainnet, self.development) {

--- a/subprojects/gdk_rust/gdk_electrum/src/account.rs
+++ b/subprojects/gdk_rust/gdk_electrum/src/account.rs
@@ -28,7 +28,7 @@ use gdk_common::util::is_confidential_txoutsecrets;
 use gdk_common::wally::{
     asset_blinding_key_to_ec_private_key, ec_public_key_from_private_key, MasterBlindingKey,
 };
-use gdk_common::{ElementsNetwork, Network, NetworkId, LIQUID_TESTNET};
+use gdk_common::{ElementsNetwork, Network, NetworkId};
 
 use crate::error::Error;
 use crate::interface::ElectrumUrl;
@@ -732,7 +732,7 @@ fn elements_address(
     script_type: ScriptType,
     net: ElementsNetwork,
 ) -> elements::Address {
-    let addr_params = elements_address_params(net);
+    let addr_params = net.address_params();
     let address = match script_type {
         ScriptType::P2pkh => elements::Address::p2pkh(public_key, None, addr_params),
         ScriptType::P2shP2wpkh => elements::Address::p2shwpkh(public_key, None, addr_params),
@@ -742,14 +742,6 @@ fn elements_address(
     let blinding_prv = asset_blinding_key_to_ec_private_key(master_blinding_key, &script_pubkey);
     let blinding_pub = ec_public_key_from_private_key(blinding_prv);
     address.to_confidential(blinding_pub)
-}
-
-fn elements_address_params(net: ElementsNetwork) -> &'static elements::AddressParams {
-    match net {
-        ElementsNetwork::Liquid => &elements::AddressParams::LIQUID,
-        ElementsNetwork::LiquidTestnet => &LIQUID_TESTNET,
-        ElementsNetwork::ElementsRegtest => &elements::AddressParams::ELEMENTS,
-    }
 }
 
 // Discover all the available accounts as per BIP 44:
@@ -883,9 +875,9 @@ pub fn create_tx(
                     info!(
                         "address.params:{:?} address_params(network):{:?}",
                         address.params,
-                        elements_address_params(network)
+                        network.address_params()
                     );
-                    if address.params == elements_address_params(network) {
+                    if address.params == network.address_params() {
                         continue;
                     }
                 }

--- a/tools/install_python.sh
+++ b/tools/install_python.sh
@@ -19,7 +19,9 @@ cp -r ${MESON_BUILD_ROOT}/src/swig_python/greenaddress .
 
 cp ${MESON_SOURCE_ROOT}/src/swig_python/setup.py .
 
-pip install wheel
+# TODO: remove setuptools pinning once the following bug is fixed
+# https://github.com/pypa/setuptools/issues/2849
+pip install -U pip 'setuptools==58.4.0' wheel
 
 pip wheel --wheel-dir=$PYTHON_DESTDIR .
 virtualenv --clear -p ${PYTHON_EXE} ${MESON_BUILD_ROOT}/smoketestvenv


### PR DESCRIPTION
setuptools 58.5 breaks our python installation script.

`elements::Address::from_str` does not work for Liquid Testnet addresses