### PR TITLE
Fix build script osx

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -196,9 +196,7 @@ if [ \( "$(uname)" != "Darwin" \) -a \( "$BUILD" = "--gcc" \) ]; then
 fi
 if [ \( "$BUILD" = "--clang" \) ]; then
     if [ \( "$(uname)" = "Darwin" \) ]; then
-        export XCODE_PATH=$(xcode-select --print-path 2>/dev/null)
-        export PLATFORM="MacOSX"
-        export SDK_PATH="$XCODE_PATH/Platforms/$PLATFORM.platform/Developer/SDKs/$PLATFORM.sdk"
+        export SDK_PATH=$(xcrun --show-sdk-path)
         export SDK_CFLAGS="$SDK_CFLAGS -isysroot ${SDK_PATH} -mmacosx-version-min=10.13"
         export SDK_LDFLAGS="$SDK_LDFLAGS -isysroot ${SDK_PATH} -mmacosx-version-min=10.13"
         export CFLAGS="${SDK_CFLAGS} -O3"

--- a/tools/ios_env.sh
+++ b/tools/ios_env.sh
@@ -1,15 +1,13 @@
 if test "x$1" == "x--iphone"; then
     export IOS_PLATFORM=iPhoneOS
     export ARCHS="-arch arm64"
+    export IOS_SDK_PATH=$(xcrun --sdk iphoneos --show-sdk-path)
 else
     export IOS_PLATFORM=iPhoneSimulator
     export ARCHS="-arch x86_64"
+    export IOS_SDK_PATH=$(xcrun --sdk iphonesimulator --show-sdk-path)
 fi
 
-export XCODE_PATH=$(xcode-select --print-path 2>/dev/null)
-export XCODE_DEFAULT_PATH="$XCODE_PATH/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-export XCODE_IOS_PATH="$XCODE_PATH/Platforms/$IOS_PLATFORM.platform/Developer/usr/bin"
-export IOS_SDK_PATH="$XCODE_PATH/Platforms/$IOS_PLATFORM.platform/Developer/SDKs/$IOS_PLATFORM.sdk"
 
 export SDK_CFLAGS_NO_ARCH="$q"
 export SDK_CFLAGS="$SDK_CFLAGS $ARCHS"

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,1 +1,2 @@
 meson==0.58.0 --hash=sha256:f4820df0bc969c99019fd4af8ca5f136ee94c63d8a5ad67e7eb73bdbc9182fdd
+virtualenv==20.15.1


### PR DESCRIPTION
Since the OSX SDK path changes depending on the XCode version installed on the machine, this updates the build script `tools/build.sh` so that it retrieves the OSX SDK path via `xcrun --show-sdk-path` instead of composing it.

This also adds the latest version of `virtualenv` to `tools/requirements.txt`. I had to manually install it to my venv every time otherwise.

Closes #166.

~~NOTE: the same problem affects the iOS SDK path and consequently [`tools/ios_env.sh`](https://github.com/Blockstream/gdk/blob/master/tools/ios_env.sh#L9-L12). I didn't make any change there because I'm not able to test since I miss the sdk. It can eventually be fixed in a later PR or you can suggest the proper fix.~~

Please @lvaccaro review this. 