### PR TITLE
Java: Fix swig mapping for functions returning uint32_t

### DIFF
--- a/src/swig_java/swig_gasdk.i
+++ b/src/swig_java/swig_gasdk.i
@@ -382,6 +382,16 @@ LOCALFUNC jbyteArray create_array(JNIEnv *jenv, const unsigned char* p, size_t l
     $1 = uint32_cast(jenv, $input);
 }
 
+/* uint32_t output pointer arguments are returned as the function return value */
+%typemap(in,noblock=1,numinputs=0) uint32_t* (uint32_t val32_out = 0) {
+    $1 = ($1_ltype)&val32_out;
+}
+%typemap(argout,noblock=1) (uint32_t*) {
+    if (!(*jenv)->ExceptionOccurred(jenv)) {
+        $result = *$1;
+    }
+}
+
 /* uint64_t input arguments are taken as longs and cast unchecked. This means
  * callers need to take care with treating negative values correctly */
 %typemap(in) uint64_t {


### PR DESCRIPTION
These calls were mapped incorrectly as taking a `long` argument, and then not returning the actual value.

In generated code this turns e.g.:

```
SWIGEXPORT jlong JNICALL Java_com_blockstream_libgreenaddress_GDK_validate_1mnemonic(JNIEnv *jenv, jclass jcls, jstring jarg1, jlong jarg2) {
  jlong jresult = 0 ;
  char *arg1 = (char *) 0 ;
  uint32_t *arg2 = (uint32_t *) 0 ;
  int result;

  (void)jenv;
  (void)jcls;
  arg1 = 0;
  if (jarg1) {
    arg1 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg1, 0);
    if (!arg1) return 0;
  }
  arg2 = jarg2;
  {
    result = (int)GA_validate_mnemonic((char const *)arg1,arg2);
    check_result(jenv, result, "GA_validate_mnemonic");
  }


  if (arg1) (*jenv)->ReleaseStringUTFChars(jenv, jarg1, (const char *)arg1);
  return jresult;
}
```

into:

```
SWIGEXPORT jlong JNICALL Java_com_blockstream_libgreenaddress_GDK_validate_1mnemonic(JNIEnv *jenv, jclass jcls, jstring jarg1) {
  jlong jresult = 0 ;
  char *arg1 = (char *) 0 ;
  uint32_t *arg2 = (uint32_t *) 0 ;
  uint32_t val32_out2 = 0 ;
  int result;

  (void)jenv;
  (void)jcls;
  arg2 = (uint32_t *)&val32_out2;
  arg1 = 0;
  if (jarg1) {
    arg1 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg1, 0);
    if (!arg1) return 0;
  }
  {
    result = (int)GA_validate_mnemonic((char const *)arg1,arg2);
    check_result(jenv, result, "GA_validate_mnemonic");
  }

  if (!(*jenv)->ExceptionOccurred(jenv)) {
    jresult = *arg2;
  }
  if (arg1) (*jenv)->ReleaseStringUTFChars(jenv, jarg1, (const char *)arg1);
  return jresult;
}
```

Note the former has a redundant `long` argument, and passes the given long argument as a pointer to the underlying gdk call.