### PR TITLE
0.63 pre-release updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Liquid: Transaction blinding is now performed using a new call
   GA_blind_transaction, which should be called after creating and before
   signing the tx.
+- Liquid: Hawrdware wallet capability JSON now contains a new field
+  "supports_external_blinding". This should be set to true when registering
+  a signer that can blind/sign transactions with blinded outputs from
+  wallets other than the callers wallet (for example, a 2 step swap).
 
 ### Changed
 - FFI (validate_call): Input JSON parameters are now moved internally and will be

--- a/docs/source/gdk-json.rst
+++ b/docs/source/gdk-json.rst
@@ -161,6 +161,7 @@ Describes the capabilities of an external signing device.
          "supports_ae_protocol": 0,
          "supports_arbitrary_scripts": true,
          "supports_host_unblinding": false,
+         "supports_external_blinding": false,
          "supports_liquid": 1,
          "supports_low_r": false,
       }
@@ -171,6 +172,8 @@ Describes the capabilities of an external signing device.
 :supports_low_r: True if the device can produce low-R ECDSA signatures.
 :supports_liquid: 0 if the device does not support Liquid, 1 otherwise.
 :supports_host_unblinding: True if the device supports returning the Liquid master blinding key.
+:supports_external_blinding: True if the device supports blinding and signing Liquid transactions
+    with outputs that are already blinded from another wallet (e.g. 2-step swaps).
 :supports_ae_protocol: See "ae_protocol_support_level" enum  in the gdk source for details.
 
 The default for any value not provided is false or 0.

--- a/src/assertion.cpp
+++ b/src/assertion.cpp
@@ -6,10 +6,10 @@
 
 namespace ga {
 namespace sdk {
-    void runtime_assert_message(const std::string& error_message, const char* file, const char* func, const char* line)
+    void runtime_assert_message(const std::string& error_message, const char* file, const char* func, unsigned int line)
     {
         const std::string msg
-            = std::string("assertion failure: ") + file + ":" + func + ":" + line + ":" + error_message;
+            = std::string("assertion failure: ") + file + ":" + func + ":" + std::to_string(line) + ":" + error_message;
         GDK_LOG_SEV(log_level::error) << msg
 #if defined(__linux__) and not defined(NDEBUG) and defined(HAVE_BACKTRACE)
                                       << "\n:backtrace " << boost::stacktrace::stacktrace()

--- a/src/assertion.cpp
+++ b/src/assertion.cpp
@@ -6,20 +6,17 @@
 
 namespace ga {
 namespace sdk {
-    void runtime_assert_message(const std::string& error_message, const char* file, const char* func, unsigned int line)
+    void runtime_assert_message(const std::string& error_message, const char* file, unsigned int line)
     {
 #ifndef __FILE_NAME__
         // Strip path from the file name
         const char* base = strrchr(file, '/');
         file = base ? base + 1 : file;
 #endif
+        const char* sep = error_message.empty() ? "" : ":";
         const std::string msg
-            = std::string("assertion failure: ") + file + ":" + func + ":" + std::to_string(line) + ":" + error_message;
-        GDK_LOG_SEV(log_level::error) << msg
-#if defined(__linux__) and not defined(NDEBUG) and defined(HAVE_BACKTRACE)
-                                      << "\n:backtrace " << boost::stacktrace::stacktrace()
-#endif
-            ;
+            = std::string("assertion failure: ") + file + ":" + std::to_string(line) + sep + error_message;
+        GDK_LOG_SEV(log_level::error) << msg;
         throw assertion_error(msg);
     }
 } // namespace sdk

--- a/src/assertion.cpp
+++ b/src/assertion.cpp
@@ -8,6 +8,11 @@ namespace ga {
 namespace sdk {
     void runtime_assert_message(const std::string& error_message, const char* file, const char* func, unsigned int line)
     {
+#ifndef __FILE_NAME__
+        // Strip path from the file name
+        const char* base = strrchr(file, '/');
+        file = base ? base + 1 : file;
+#endif
         const std::string msg
             = std::string("assertion failure: ") + file + ":" + func + ":" + std::to_string(line) + ":" + error_message;
         GDK_LOG_SEV(log_level::error) << msg

--- a/src/assertion.hpp
+++ b/src/assertion.hpp
@@ -6,8 +6,7 @@
 
 namespace ga {
 namespace sdk {
-    void runtime_assert_message(
-        const std::string& error_message, const char* file, const char* func, unsigned int line);
+    void runtime_assert_message(const std::string& error_message, const char* file, unsigned int line);
 }
 } // namespace ga
 
@@ -15,15 +14,14 @@ namespace sdk {
 #define GDK_RUNTIME_ASSERT_MSG(condition, error_message)                                                               \
     do {                                                                                                               \
         if (!(condition)) {                                                                                            \
-            ga::sdk::runtime_assert_message(                                                                           \
-                error_message, __FILE_NAME__, static_cast<const char*>(__func__), __LINE__);                           \
+            ga::sdk::runtime_assert_message(error_message, __FILE_NAME__, __LINE__);                                   \
         }                                                                                                              \
     } while (false)
 #else
 #define GDK_RUNTIME_ASSERT_MSG(condition, error_message)                                                               \
     do {                                                                                                               \
         if (!(condition)) {                                                                                            \
-            ga::sdk::runtime_assert_message(error_message, __FILE__, static_cast<const char*>(__func__), __LINE__);    \
+            ga::sdk::runtime_assert_message(error_message, __FILE__, __LINE__);                                        \
         }                                                                                                              \
     } while (false)
 #endif

--- a/src/assertion.hpp
+++ b/src/assertion.hpp
@@ -11,18 +11,23 @@ namespace sdk {
 }
 } // namespace ga
 
-#define GDK_RUNTIME_ASSERT(condition)                                                                                  \
+#ifdef __FILE_NAME__
+#define GDK_RUNTIME_ASSERT_MSG(condition, error_message)                                                               \
     do {                                                                                                               \
         if (!(condition)) {                                                                                            \
-            ga::sdk::runtime_assert_message(std::string(), __FILE__, static_cast<const char*>(__func__), __LINE__);    \
+            ga::sdk::runtime_assert_message(                                                                           \
+                error_message, __FILE_NAME__, static_cast<const char*>(__func__), __LINE__);                           \
         }                                                                                                              \
     } while (false)
+#else
 #define GDK_RUNTIME_ASSERT_MSG(condition, error_message)                                                               \
     do {                                                                                                               \
         if (!(condition)) {                                                                                            \
             ga::sdk::runtime_assert_message(error_message, __FILE__, static_cast<const char*>(__func__), __LINE__);    \
         }                                                                                                              \
     } while (false)
+#endif
+#define GDK_RUNTIME_ASSERT(condition) GDK_RUNTIME_ASSERT_MSG(condition, std::string());
 #define GDK_VERIFY(x) GDK_RUNTIME_ASSERT((x) == WALLY_OK)
 
 #define NET_ERROR_CODE_CHECK(msg, ec)                                                                                  \

--- a/src/assertion.hpp
+++ b/src/assertion.hpp
@@ -6,24 +6,21 @@
 
 namespace ga {
 namespace sdk {
-    void runtime_assert_message(const std::string& error_message, const char* file, const char* func, const char* line);
+    void runtime_assert_message(
+        const std::string& error_message, const char* file, const char* func, unsigned int line);
 }
 } // namespace ga
 
-#define GDK_STRINGIFY_(x) #x
-#define GDK_STRINGIFY(x) GDK_STRINGIFY_(x)
 #define GDK_RUNTIME_ASSERT(condition)                                                                                  \
     do {                                                                                                               \
         if (!(condition)) {                                                                                            \
-            ga::sdk::runtime_assert_message(                                                                           \
-                std::string(), __FILE__, static_cast<const char*>(__func__), GDK_STRINGIFY(__LINE__));                 \
+            ga::sdk::runtime_assert_message(std::string(), __FILE__, static_cast<const char*>(__func__), __LINE__);    \
         }                                                                                                              \
     } while (false)
 #define GDK_RUNTIME_ASSERT_MSG(condition, error_message)                                                               \
     do {                                                                                                               \
         if (!(condition)) {                                                                                            \
-            ga::sdk::runtime_assert_message(                                                                           \
-                error_message, __FILE__, static_cast<const char*>(__func__), GDK_STRINGIFY(__LINE__));                 \
+            ga::sdk::runtime_assert_message(error_message, __FILE__, static_cast<const char*>(__func__), __LINE__);    \
         }                                                                                                              \
     } while (false)
 #define GDK_VERIFY(x) GDK_RUNTIME_ASSERT((x) == WALLY_OK)

--- a/src/boost_wrapper.hpp
+++ b/src/boost_wrapper.hpp
@@ -40,11 +40,6 @@
 #include <boost/multiprecision/cpp_dec_float.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/smart_ptr/atomic_shared_ptr.hpp>
-#if defined(__linux__) and not defined(NDEBUG) and defined(HAVE_BACKTRACE)
-#define BOOST_STACKTRACE_USE_ADDR2LINE
-#define BOOST_STACKTRACE_USE_BACKTRACE
-#include <boost/stacktrace.hpp>
-#endif
 #include <boost/thread/tss.hpp>
 
 #if __clang__

--- a/src/ga_cache.cpp
+++ b/src/ga_cache.cpp
@@ -24,7 +24,7 @@ namespace sdk {
         constexpr uint32_t CT_WO = 2; // Watch-only wallet cache
 
         constexpr int VERSION = 1;
-        constexpr int MINOR_VERSION = 0x2;
+        constexpr int MINOR_VERSION = 0x3;
         constexpr const char* KV_SELECT = "SELECT value FROM KeyValue WHERE key = ?1;";
         constexpr const char* TX_SELECT = "SELECT timestamp, txid, block, spent, spv_status, data FROM Tx "
                                           "WHERE subaccount = ?1 ORDER BY timestamp DESC LIMIT ?2 OFFSET ?3;";
@@ -531,8 +531,8 @@ namespace sdk {
                 exec_sql(m_db, "DELETE FROM LiquidOutput;");
                 exec_sql(m_db, "DELETE FROM LiquidBlindingNonce;");
             }
-            if (ver < 2) {
-                // Delete pre-v2 tx's
+            if (ver < 3) {
+                // Delete pre-v3 tx's
                 exec_sql(m_db, "DELETE FROM Tx;");
             }
 

--- a/src/ga_tx.cpp
+++ b/src/ga_tx.cpp
@@ -1338,17 +1338,18 @@ namespace sdk {
                 }
             } else {
                 GDK_RUNTIME_ASSERT(!output.contains("nonce_commitment"));
-                auto eph_keypair = get_ephemeral_keypair();
-                eph_public_key = std::move(eph_keypair.second);
+                priv_key_t eph_private_key;
+                std::tie(eph_private_key, eph_public_key) = get_ephemeral_keypair();
+                output["eph_public_key"] = b2h(eph_public_key);
                 const auto blinding_pubkey = h2b(output.at("blinding_key"));
                 GDK_RUNTIME_ASSERT(!output.contains("blinding_nonce"));
                 if (blinding_nonces_required) {
                     // Generate the blinding nonce for the caller
-                    const auto nonce = sha256(ecdh(blinding_pubkey, eph_keypair.first));
+                    const auto nonce = sha256(ecdh(blinding_pubkey, eph_private_key));
                     blinding_nonces.emplace_back(b2h(nonce));
                 }
 
-                rangeproof = asset_rangeproof(value, blinding_pubkey, eph_keypair.first, asset_id, abf, vbf,
+                rangeproof = asset_rangeproof(value, blinding_pubkey, eph_private_key, asset_id, abf, vbf,
                     value_commitment, scriptpubkey, generator);
             }
 

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -198,7 +198,7 @@ namespace sdk {
 
     std::future<nlohmann::json> http_client::request(beast::http::verb verb, const nlohmann::json& params)
     {
-        GDK_LOG_NAMED_SCOPE("http_client");
+        GDK_LOG_SEV(log_level::debug) << "http_client";
 
         m_host = params.at("host");
         m_port = params.at("port");
@@ -262,7 +262,7 @@ namespace sdk {
 
     void http_client::on_resolve(beast::error_code ec, asio::ip::tcp::resolver::results_type results)
     {
-        GDK_LOG_NAMED_SCOPE("http_client:on_resolve");
+        GDK_LOG_SEV(log_level::debug) << "http_client:on_resolve";
 
         NET_ERROR_CODE_CHECK("on resolve", ec);
         get_lowest_layer().expires_after(m_timeout);
@@ -271,7 +271,7 @@ namespace sdk {
 
     void http_client::on_write(beast::error_code ec, size_t __attribute__((unused)) bytes_transferred)
     {
-        GDK_LOG_NAMED_SCOPE("http_client:on_write");
+        GDK_LOG_SEV(log_level::debug) << "http_client:on_write";
 
         NET_ERROR_CODE_CHECK("on write", ec);
         get_lowest_layer().expires_after(m_timeout);
@@ -281,7 +281,7 @@ namespace sdk {
 
     void http_client::on_read(beast::error_code ec, size_t __attribute__((unused)) bytes_transferred)
     {
-        GDK_LOG_NAMED_SCOPE("http_client:on_read");
+        GDK_LOG_SEV(log_level::debug) << "http_client:on_read";
 
         NET_ERROR_CODE_CHECK("on read", ec);
         get_lowest_layer().cancel();
@@ -290,7 +290,7 @@ namespace sdk {
 
     void http_client::on_shutdown(beast::error_code ec)
     {
-        GDK_LOG_NAMED_SCOPE("http_client");
+        GDK_LOG_SEV(log_level::debug) << "http_client";
 
         if (ec && ec != asio::error::eof && ec != asio::ssl::error::stream_truncated) {
             set_exception(ec.message());
@@ -364,7 +364,7 @@ namespace sdk {
     void tls_http_client::on_connect(
         beast::error_code ec, __attribute__((unused)) const asio::ip::tcp::resolver::results_type::endpoint_type& type)
     {
-        GDK_LOG_NAMED_SCOPE("http_client:on_connect");
+        GDK_LOG_SEV(log_level::debug) << "http_client:on_connect";
 
         NET_ERROR_CODE_CHECK("on connect", ec);
         async_handshake();
@@ -372,7 +372,7 @@ namespace sdk {
 
     void tls_http_client::on_handshake(beast::error_code ec)
     {
-        GDK_LOG_NAMED_SCOPE("http_client:on_handshake");
+        GDK_LOG_SEV(log_level::debug) << "http_client:on_handshake";
 
         NET_ERROR_CODE_CHECK("on handshake", ec);
         get_lowest_layer().expires_after(m_timeout);
@@ -464,7 +464,7 @@ namespace sdk {
     void tcp_http_client::on_connect(boost::beast::error_code ec,
         __attribute__((unused)) const boost::asio::ip::tcp::resolver::results_type::endpoint_type& type)
     {
-        GDK_LOG_NAMED_SCOPE("tcp_http_client");
+        GDK_LOG_SEV(log_level::debug) << "tcp_http_client";
 
         NET_ERROR_CODE_CHECK("on connect", ec);
 

--- a/src/logging.hpp
+++ b/src/logging.hpp
@@ -95,10 +95,6 @@ namespace sdk {
         return gdk_logger_t{};
     }
 
-#define GDK_LOG_NAMED_SCOPE(name)                                                                                      \
-    BOOST_LOG_SEV(::ga::sdk::gdk_logger::get(), log_level::severity_level::debug)                                      \
-        << __FILE__ << ':' << __LINE__ << ':' << (name) << ':' << __func__; // NOLINT: compiler specific types.
-
 #define GDK_LOG_SEV(sev) BOOST_LOG_SEV(::ga::sdk::gdk_logger::get(), sev)
 
     class websocket_boost_logger {

--- a/src/signer.cpp
+++ b/src/signer.cpp
@@ -86,17 +86,17 @@ namespace sdk {
 
         static const nlohmann::json GREEN_DEVICE_JSON{ { "device_type", "green-backend" }, { "supports_low_r", true },
             { "supports_arbitrary_scripts", true }, { "supports_host_unblinding", false },
-            { "supports_liquid", liquid_support_level::lite },
+            { "supports_external_blinding", true }, { "supports_liquid", liquid_support_level::lite },
             { "supports_ae_protocol", ae_protocol_support_level::none } };
 
         static const nlohmann::json WATCH_ONLY_DEVICE_JSON{ { "device_type", "watch-only" }, { "supports_low_r", true },
             { "supports_arbitrary_scripts", true }, { "supports_host_unblinding", true },
-            { "supports_liquid", liquid_support_level::lite },
+            { "supports_external_blinding", true }, { "supports_liquid", liquid_support_level::lite },
             { "supports_ae_protocol", ae_protocol_support_level::none } };
 
         static const nlohmann::json SOFTWARE_DEVICE_JSON{ { "device_type", "software" }, { "supports_low_r", true },
             { "supports_arbitrary_scripts", true }, { "supports_host_unblinding", true },
-            { "supports_liquid", liquid_support_level::lite },
+            { "supports_external_blinding", true }, { "supports_liquid", liquid_support_level::lite },
             { "supports_ae_protocol", ae_protocol_support_level::none } };
 
         static nlohmann::json get_device_json(const nlohmann::json& hw_device, const nlohmann::json& credentials)
@@ -122,6 +122,7 @@ namespace sdk {
             json_add_if_missing(ret, "supports_low_r", false, overwrite_null);
             json_add_if_missing(ret, "supports_arbitrary_scripts", false, overwrite_null);
             json_add_if_missing(ret, "supports_host_unblinding", false, overwrite_null);
+            json_add_if_missing(ret, "supports_external_blinding", true, overwrite_null);
             json_add_if_missing(ret, "supports_liquid", liquid_support_level::none, overwrite_null);
             json_add_if_missing(ret, "supports_ae_protocol", ae_protocol_support_level::none, overwrite_null);
             json_add_if_missing(ret, "device_type", std::string("hardware"), overwrite_null);
@@ -223,6 +224,8 @@ namespace sdk {
     liquid_support_level signer::get_liquid_support() const { return m_device["supports_liquid"]; }
 
     bool signer::supports_host_unblinding() const { return m_device["supports_host_unblinding"]; }
+
+    bool signer::supports_external_blinding() const { return m_device["supports_external_blinding"]; }
 
     ae_protocol_support_level signer::get_ae_protocol_support() const { return m_device["supports_ae_protocol"]; }
 

--- a/src/signer.hpp
+++ b/src/signer.hpp
@@ -50,23 +50,26 @@ namespace sdk {
         signer& operator=(signer&&) = delete;
         virtual ~signer();
 
-        // Returns true if if this signers credentials and HW device match 'other'
+        // Returns true if this signers credentials and HW device match 'other'
         bool is_compatible_with(std::shared_ptr<signer> other) const;
 
         // Return the mnemonic associated with this signer (empty if none available)
         std::string get_mnemonic(const std::string& password);
 
-        // Returns true if if this signer produces only low-r signatures
+        // Returns true if this signer produces only low-r signatures
         bool supports_low_r() const;
 
-        // Returns true if if this signer can sign arbitrary scripts
+        // Returns true if this signer can sign arbitrary scripts
         bool supports_arbitrary_scripts() const;
 
         // Returns the level of liquid support
         liquid_support_level get_liquid_support() const;
 
-        // Returns true if if this signer can export the master blinding key
+        // Returns true if this signer can export the master blinding key
         bool supports_host_unblinding() const;
+
+        // Returns true if this signer can sign txs with externally blinded outputs
+        bool supports_external_blinding() const;
 
         // Returns how this signer supports the Anti-Exfil protocol
         ae_protocol_support_level get_ae_protocol_support() const;

--- a/src/socks_client.cpp
+++ b/src/socks_client.cpp
@@ -21,7 +21,7 @@ namespace sdk {
 
     std::future<void> socks_client::run(const std::string& endpoint, const std::string& proxy_uri)
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:run");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:run";
 
         m_endpoint = endpoint;
 
@@ -43,7 +43,7 @@ namespace sdk {
 
     void socks_client::shutdown()
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:shutdown");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:shutdown";
 
         beast::error_code ec;
         m_stream.socket().shutdown(asio::ip::tcp::socket::shutdown_both, ec);
@@ -54,7 +54,7 @@ namespace sdk {
 
     void socks_client::on_resolve(beast::error_code ec, const asio::ip::tcp::resolver::results_type& results)
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:on_resolve");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:on_resolve";
 
         NET_ERROR_CODE_CHECK("socks_client", ec);
         m_stream.async_connect(results, beast::bind_front_handler(&socks_client::on_connect, shared_from_this()));
@@ -63,7 +63,7 @@ namespace sdk {
     void socks_client::on_connect(
         beast::error_code ec, __attribute__((unused)) const asio::ip::tcp::resolver::results_type::endpoint_type& type)
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:on_connect");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:on_connect";
 
         NET_ERROR_CODE_CHECK("socks_client", ec);
 
@@ -75,7 +75,7 @@ namespace sdk {
 
     void socks_client::on_write(boost::beast::error_code ec, size_t __attribute__((unused)) bytes_transferred)
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:on_write");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:on_write";
 
         NET_ERROR_CODE_CHECK("socks_client", ec);
 
@@ -86,7 +86,7 @@ namespace sdk {
 
     void socks_client::on_read(boost::beast::error_code ec, size_t __attribute__((unused)) bytes_transferred)
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:on_read");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:on_read";
 
         NET_ERROR_CODE_CHECK("socks_client", ec);
 
@@ -124,7 +124,7 @@ namespace sdk {
 
     void socks_client::on_connect_read(boost::beast::error_code ec, size_t __attribute__((unused)) bytes_transferred)
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:on_connect_read");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:on_connect_read";
 
         NET_ERROR_CODE_CHECK("socks_client", ec);
 
@@ -144,7 +144,7 @@ namespace sdk {
     void socks_client::on_domain_name_read(
         boost::beast::error_code ec, size_t __attribute__((unused)) bytes_transferred)
     {
-        GDK_LOG_NAMED_SCOPE("socks_client:on_domain_name_read");
+        GDK_LOG_SEV(log_level::debug) << "socks_client:on_domain_name_read";
 
         NET_ERROR_CODE_CHECK("socks_client", ec);
 

--- a/src/transaction_utils.cpp
+++ b/src/transaction_utils.cpp
@@ -5,6 +5,7 @@
 #include "ga_strings.hpp"
 #include "memory.hpp"
 #include "session_impl.hpp"
+#include "signer.hpp"
 #include "transaction_utils.hpp"
 #include "utils.hpp"
 #include "xpub_hdkey.hpp"
@@ -448,6 +449,9 @@ namespace sdk {
                 throw user_error(res::id_invalid_address);
             }
             const bool is_blinded = is_liquid && addressee.value("is_blinded", false);
+            if (is_blinded && !session.get_nonnull_signer()->supports_external_blinding()) {
+                throw user_error("Signing device does not support externally blinded transactions");
+            }
 
             // BIP21
             auto uri = parse_bitcoin_uri(net_params, address);


### PR DESCRIPTION
Minimal changes required for upcoming release.

- Bump the tx cache version
- Provide ephemeral public key for blinding/signing
- Add a "supports_external_blinding" capability for HWW
- Logging/assertion updates

Note that "supports_external_blinding" defaults to true but will revert to false post-release.
