### PR TITLE
Allow signing messages on liquid

### DIFF
--- a/src/ga_auth_handlers.cpp
+++ b/src/ga_auth_handlers.cpp
@@ -2098,7 +2098,7 @@ namespace sdk {
 
     auth_handler::state_type sign_message_call::call_impl()
     {
-        GDK_RUNTIME_ASSERT_MSG(m_net_params.is_electrum() && !m_net_params.is_liquid(), "Invalid network");
+        GDK_RUNTIME_ASSERT_MSG(m_net_params.is_electrum(), "Invalid network");
         auto signer = get_signer();
 
         if (m_address_data.empty()) {


### PR DESCRIPTION
I can sign a message on Bitcoin:
```
$ green-cli --network electrum-testnet getnewaddress                                                                                                                                                                                                                                                             
2N3t2fZsYE6QVBAoG3Z8cpq2oadsp6Smv2h
$ green-cli --network electrum-testnet signmessage 2N3t2fZsYE6QVBAoG3Z8cpq2oadsp6Smv2h "Hello"                                                                                                                                                                                                                   
{
  "signature": "H29dlu1Ce+icNUMY6XfcgK6+z5140vbWHfQ1BoVpOWnDQa99pnojqLdUodJIrb4hKfDsbxob7Ap+xvvi3hYS16M="
}
```
But doing the same thing on liquid yields to an error:
```
$ green-cli --network electrum-testnet-liquid getnewaddress                                                                                                                                                                                                                                                      
vjTwMefCmqyvk7yFRN7ixCaEJRz9XKA9ie8nJDoo7TfQDF9jHZ3mEGvNXhNsHwriM7hqVtLZqDtT8SRe
$ green-cli --network electrum-testnet-liquid signmessage vjTwMefCmqyvk7yFRN7ixCaEJRz9XKA9ie8nJDoo7TfQDF9jHZ3mEGvNXhNsHwriM7hqVtLZqDtT8SRe "Hello"                                                                                                                                                               
...
RuntimeError: OrderedDict([('action', 'sign_message'), ('error', 'assertion failure: ga_auth_handlers.cpp:2101:Invalid network'), ('name', 'sign_message'), ('status', 'error')])
```