### PR TITLE
[FIX] Fixed reference to deprecated function PyEval_CallObject

### DIFF
--- a/src/swig_python/swig_green_gdk.i
+++ b/src/swig_python/swig_green_gdk.i
@@ -138,7 +138,7 @@ static void notification_handler(void* context_p, GA_json* details)
         goto end;
 
     /* Call the weak reference to get the handler (if available) */
-    handler = PyEval_CallObject(handler_ref, NULL);
+    handler = PyObject_CallObject(handler_ref, NULL);
     if (!handler)
         goto end;
 
@@ -148,7 +148,7 @@ static void notification_handler(void* context_p, GA_json* details)
         if (!args)
             goto end;
 
-        ret = PyEval_CallObject(handler, args);
+        ret = PyObject_CallObject(handler, args);
         Py_DecRef(args);
         if (ret)
             Py_DecRef(ret); /* Ignore any return value */


### PR DESCRIPTION
PyEval_CallObject() has been deprecated since Python 3.9 (https://docs.python.org/3.13/whatsnew/3.9.html), and thus building the Python wrapper fails with the following errors when compiling with clang:

```
swig_green_gdk_wrap.c:3359:15: error: call to undeclared function 'PyEval_CallObject'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
 3359 |     handler = PyEval_CallObject(handler_ref, NULL);
      |               ^
swig_green_gdk_wrap.c:3359:13: error: incompatible integer to pointer conversion assigning to 'PyObject *' (aka 'struct _object *') from 'int' [-Wint-conversion]
 3359 |     handler = PyEval_CallObject(handler_ref, NULL);
      |             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
swig_green_gdk_wrap.c:3369:13: error: incompatible integer to pointer conversion assigning to 'PyObject *' (aka 'struct _object *') from 'int' [-Wint-conversion]
 3369 |         ret = PyEval_CallObject(handler, args);
      |             ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 errors generated.
```
The current Python specs recommend to use PyObject_CallObject() instead of PyEval_CallObject(). This PR changes the swig_green_gdk.i file to reflect these recommendations.