### PR TITLE
Div by 256 -> shift

### DIFF
--- a/src/ga_session.cpp
+++ b/src/ga_session.cpp
@@ -69,12 +69,10 @@ namespace green {
         // TODO: too slow. lacks validation.
         static std::array<unsigned char, SHA256_LEN> uint256_to_base256(const std::string& input)
         {
-            constexpr size_t base = 256;
-
             std::array<unsigned char, SHA256_LEN> repr{};
             size_t i = repr.size() - 1;
-            for (boost::multiprecision::checked_uint256_t num(input); num; num = num / base, --i) {
-                repr[i] = static_cast<unsigned char>(num % base);
+            for (boost::multiprecision::checked_uint256_t num(input); num; num >>= 8, --i) {
+                repr[i] = static_cast<unsigned char>(num % 256);
             }
 
             return repr;

--- a/src/ga_session.hpp
+++ b/src/ga_session.hpp
@@ -192,8 +192,6 @@ namespace green {
             const std::string& name, const std::string& receiving_id, const std::optional<xpub_hdkey>& recovery_key,
             uint32_t required_ca);
 
-        std::pair<std::string, std::string> sign_challenge(locker_t& locker, const std::string& challenge);
-
         void set_fee_estimates(locker_t& locker, const nlohmann::json& fee_estimates);
 
         nlohmann::json refresh_http_data(const std::string& page, const std::string& key, bool refresh);


### PR DESCRIPTION
[TODO](https://github.com/Blockstream/gdk/blob/86315eb265ef0d87dbbf2f8f0860aec76773e657/src/ga_session.cpp#L69) notes slowness, so change divide by 256 to right shift by a byte. On x86_64 with gcc, logarithmic gains between 0 bit input (same speed) and 256 bit input (2.65x faster). 1.7x speedup on average

