### PR TITLE
build: make outputs independent of the checkout path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 project(gdk VERSION 0.77.7 LANGUAGES C CXX)
 
+# Keep the absolute checkout path out of compiled output.
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    add_compile_options("-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/cmake/includes/helpers.cmake
+++ b/cmake/includes/helpers.cmake
@@ -63,7 +63,7 @@ macro(create_gdkrust_target)
     # cmake_path(GET OPENSSL_INCLUDE_DIR ROOT_DIRECTORY OPENSSL_ROOT_DIR)
     set(OPENSSL_ROOT_DIR ${CMAKE_PREFIX_PATH})
     add_custom_target(cargo-cmd
-        COMMAND ${_buildTool} "${CMAKE_BUILD_TYPE}" "${_rustTriple}" "${ANDROID_TOOLCHAIN_ROOT}" ${CMAKE_AR} ${OPENSSL_INCLUDE_DIR} ${OPENSSL_CRYPTO_LIBRARY} ${_gdkRustSrcDir} ${_gdkRustBuildDir} ${_gdkRustLibArtifact} "${CMAKE_OSX_DEPLOYMENT_TARGET}"
+        COMMAND ${_buildTool} "${CMAKE_BUILD_TYPE}" "${_rustTriple}" "${ANDROID_TOOLCHAIN_ROOT}" ${CMAKE_AR} ${OPENSSL_INCLUDE_DIR} ${OPENSSL_CRYPTO_LIBRARY} ${_gdkRustSrcDir} ${_gdkRustBuildDir} ${_gdkRustLibArtifact} "${CMAKE_OSX_DEPLOYMENT_TARGET}" "${CMAKE_SOURCE_DIR}"
         VERBATIM
         BYPRODUCTS ${_gdkRustLibArtifact}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/tools/buildgdk_rust.sh
+++ b/tools/buildgdk_rust.sh
@@ -11,6 +11,7 @@ SOURCE_DIR="$1"; shift
 OUTPUT_DIR="$1"; shift
 ARTIFACT="$1"; shift
 export MACOSX_DEPLOYMENT_TARGET=$1; shift
+GDK_ROOT="$1"; shift
 
 export CC_i686_linux_android=i686-linux-android23-clang
 export CARGO_TARGET_I686_LINUX_ANDROID_LINKER=${CC_i686_linux_android}
@@ -21,6 +22,12 @@ export CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=${CC_armv7_linux_androideabi}
 export CC_aarch64_linux_android=aarch64-linux-android23-clang
 export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${CC_aarch64_linux_android}
 export AR=${ARCHIVER}
+
+# rustc flags this script must contribute.
+GDK_RUSTC_FLAGS=()
+if [ -n "${GDK_ROOT}" ]; then
+    GDK_RUSTC_FLAGS+=("--remap-path-prefix=${GDK_ROOT}=.")
+fi
 
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
@@ -91,7 +98,7 @@ fi
 
 if [[ ${TRIPLE} == *"android"* ]];then
     export PATH=${PATH}:${ANDROID_TOOLCHAIN_ROOT}/bin
-    export RUSTFLAGS="-L${SOURCE_DIR}/libgcc"
+    GDK_RUSTC_FLAGS+=("-L${SOURCE_DIR}/libgcc")
 elif [[ ${TRIPLE} == "aarch64-apple-ios" ]]; then
     LD_ARCH="-arch arm64 -platform_version ios ${MACOSX_DEPLOYMENT_TARGET} ${MACOSX_DEPLOYMENT_TARGET}"
 elif [[ ${TRIPLE} == "x86_64-apple-ios" ]]; then
@@ -102,6 +109,25 @@ elif [[ ${TRIPLE} == "aarch64-apple-darwin" ]]; then
     LD_ARCH="-arch arm64 -platform_version macos ${MACOSX_DEPLOYMENT_TARGET} ${MACOSX_DEPLOYMENT_TARGET}"
 elif [[ ${TRIPLE} == "x86_64-apple-darwin" ]]; then
     LD_ARCH="-arch x86_64 -platform_version macos ${MACOSX_DEPLOYMENT_TARGET} ${MACOSX_DEPLOYMENT_TARGET}"
+fi
+
+# Cargo uses CARGO_ENCODED_RUSTFLAGS instead of RUSTFLAGS when the encoded
+# variable is set, even when it is empty. Append to the source Cargo will use.
+if [ ${#GDK_RUSTC_FLAGS[@]} -gt 0 ]; then
+    if [ -n "${CARGO_ENCODED_RUSTFLAGS+set}" ]; then
+        _gdk_us=$'\x1f'
+        for _gdk_flag in "${GDK_RUSTC_FLAGS[@]}"; do
+            CARGO_ENCODED_RUSTFLAGS="${CARGO_ENCODED_RUSTFLAGS:+${CARGO_ENCODED_RUSTFLAGS}${_gdk_us}}${_gdk_flag}"
+        done
+        export CARGO_ENCODED_RUSTFLAGS
+        unset _gdk_us _gdk_flag
+    else
+        for _gdk_flag in "${GDK_RUSTC_FLAGS[@]}"; do
+            RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }${_gdk_flag}"
+        done
+        export RUSTFLAGS
+        unset _gdk_flag
+    fi
 fi
 
 # behaving correctly when no-op

--- a/tools/buildgdk_rust.sh
+++ b/tools/buildgdk_rust.sh
@@ -43,6 +43,7 @@ ARTIFACT_PATH_HINT=${OUTPUT_DIR}
 CARGO_ARGS=()
 CARGO_ARGS+=("--manifest-path=${SOURCE_DIR}/Cargo.toml")
 CARGO_ARGS+=("--target-dir=${OUTPUT_DIR}")
+CARGO_ARGS+=("--locked")
 
 if [ "$BUILDTYPE" == "Release" ]; then
     CARGO_ARGS+=("--release")


### PR DESCRIPTION
## Summary

Make GDK’s C++ and Rust outputs independent of the absolute checkout path.

This fixes #225 and allows third parties to reproduce GDK without recreating Blockstream’s CI directory structure.

## Problem

GDK embedded its absolute source directory into compiled output.

Using `release_0.77.6`, the same source, builder image, dependencies, and build command produced different Android libraries at different checkout paths:

| Checkout path | `libgreen_gdk_java.so` SHA-256 |
|---|---|
| `/root/gdk` | `b60ce800…` |
| `/root/gdk/gdk` | `440ca6ed…` |
| `/builds/blockstream/gdk` | `fbcd5f11…` |
| `/builds/blockstream/green/gdk` | `13d4ba62…` |

Only the final path reproduced the published library.

## Changes

- Add `-ffile-prefix-map=${CMAKE_SOURCE_DIR}=.` to supported C and C++ builds.
- Pass the top-level source root into the Rust build script.
- Add Rust’s `--remap-path-prefix` without discarding inherited flags.
- Preserve Android’s required `-L…/libgcc` flag.
- Respect `CARGO_ENCODED_RUSTFLAGS` when Cargo uses it instead of `RUSTFLAGS`.
- Pass `--locked` to Cargo, as requested in #225.

The C++ and Rust changes are separate commits. I kept `--locked` in a third commit because dependency locking has a separate rationale, but I am happy to fold it into the Rust commit if preferred.

## Verification

Tested commit `4cf8443ad17aaae66a13a0de2b5f927b925c3d9c` with the pinned builder:

```text
docker.io/blockstream/gdk-android-builder@sha256:e08f5a77cc5472c9539cd0a83ee376efffab02eff4e768eae2c16c243f587f1e
```

I made two clean arm64 Android Release builds with identical inputs but different checkout paths:

- Build A: `/builds/blockstream/green/gdk`
- Build B: `/root/gdk`

All four outputs were byte-for-byte identical:

| Output | SHA-256 for both builds |
|---|---|
| `src/libgreen_gdk.a` | `48ce7e4313decc8220b0479032632a77b7b79e73292619ee147475ecb88d1ab0` |
| `gdk-rust/libgdk_rust.a` | `a2157fcadb08e9990e277e43a64e8c7819450665faeab6e6439d71c9d7471f45` |
| `libgreen_gdk_java.so` | `1aa34e6fd3f565f759350909d16ee57ee58aa4c4d709f5b211b7b49a4515644e` |
| `libgreen_gdk_java.syms` | `48b8dcb14034b1c0b7eb52c86e4f838d5958348923e01271add8201875c99ac5` |

Additional checks:

- Neither absolute checkout path remained in the four outputs.
- Neither path remained in the tested C/C++ object files.
- Verbose rustc output contained the correct `--remap-path-prefix` for each build.
- Android’s `-L…/libgcc` flag remained present.
- Both builds used `--locked`.
- The `.syms` file still resolved a machine address to a real function and source line.

The patched hashes are intentionally different from the old release hash because path remapping changes the recorded strings. The relevant result is that the two patched builds match each other.

## Scope

The acceptance test covers the arm64 Android Release build. No wallet behavior, protocol handling, or key-management code is changed.